### PR TITLE
Fix import statement for dashscope

### DIFF
--- a/hello_agents/memory/embedding.py
+++ b/hello_agents/memory/embedding.py
@@ -168,10 +168,10 @@ class DashScopeEmbedding(EmbeddingModel):
 
     def _init_client(self):
         try:
-            import dashscope  # noqa: F401
             if self.api_key:
                 # 将统一命名的 API Key 注入到 SDK 期望的位置
                 os.environ["DASHSCOPE_API_KEY"] = self.api_key
+            import dashscope  # noqa: F401
         except ImportError:
             raise ImportError("请安装 dashscope: pip install dashscope")
 


### PR DESCRIPTION
Environment variables (such as os.environ["DASHSCOPE_API_KEY"]) must be set before the dashscope SDK is imported and initialized. If dashscope has been imported or initialized before setting the environment variable, the SDK may have cached the environment variable and setting it later will not take effect.