### PR TITLE
fix: fix some bugs

### DIFF
--- a/hello_agents/agents/simple_agent.py
+++ b/hello_agents/agents/simple_agent.py
@@ -344,7 +344,7 @@ class SimpleAgent(Agent):
     def remove_tool(self, tool_name: str) -> bool:
         """移除工具（便利方法）"""
         if self.tool_registry:
-            return self.tool_registry.unregister_tool(tool_name)
+            return self.tool_registry.unregister(tool_name)
         return False
 
     def list_tools(self) -> list:

--- a/hello_agents/rl/rewards.py
+++ b/hello_agents/rl/rewards.py
@@ -234,7 +234,7 @@ def evaluate_rewards(
     Returns:
         评估结果字典
     """
-    rewards = reward_fn(completions, ground_truths=ground_truths)
+    rewards = reward_fn(completions, ground_truth=ground_truths)
     
     return {
         "mean_reward": sum(rewards) / len(rewards) if rewards else 0.0,
@@ -259,7 +259,7 @@ if __name__ == "__main__":
     ground_truths = ["2", "2", "2"]
     
     # 计算奖励
-    rewards = reward_fn(completions, ground_truths)
+    rewards = reward_fn(completions, ground_truth=ground_truths)
     print("Rewards:", rewards)
     
     # 评估

--- a/hello_agents/tools/builtin/gaia_evaluation_tool.py
+++ b/hello_agents/tools/builtin/gaia_evaluation_tool.py
@@ -449,7 +449,7 @@ GAIA要求的JSONL格式（每行一个JSON对象）：
             数据集信息字典
         """
         try:
-            dataset = GAIADataset(level=level, local_data_path=self.local_data_path)
+            dataset = GAIADataset(level=level, local_data_dir=self.local_data_path)
             items = dataset.load()
             
             # 获取统计信息

--- a/hello_agents/tools/builtin/protocol_tools.py
+++ b/hello_agents/tools/builtin/protocol_tools.py
@@ -129,7 +129,8 @@ class MCPTool(Tool):
 
         super().__init__(
             name=name,
-            description=description
+            description=description,
+            expandable=auto_expand,
         )
 
     def _prepare_env(self,


### PR DESCRIPTION
- **MCPTool 无法自动展开**
    - **文件**: hello_agents/tools/builtin/protocol_tools.py
    - **修复**: 在 MCPTool.**init** 中，为父类 Tool 的构造函数补充了 **`expandable=auto_expand`** 参数。这使得 ToolRegistry 能够正确识别并展开 MCPTool。
- **RL 奖励函数参数名错误**
    - **文件**: hello_agents/rl/rewards.py
    - **修复**: 在 evaluate_rewards 函数中，调用 reward_fn 时，将关键字参数从 **`ground_truths`** 改为 **`ground_truth`**，与 MathRewardFunction 的定义保持一致。
- **GAIA 数据集参数名错误**
    - **文件**: hello_agents/tools/builtin/gaia_evaluation_tool.py
    - **修复**: 在 GAIAEvaluationTool 中，初始化 GAIADataset 时，将参数名从 **`local_data_path`** 改为 **`local_data_dir`**，以匹配 GAIADataset 的构造函数。
- **Agent 工具注册与管理**
    - **文件**: hello_agents/agents/simple_agent.py
        - **修复**: SimpleAgent.remove_tool 方法中，将对 **`self.tool_registry.unregister_tool()`** 的调用修正为 self.tool_registry.unregister()，修复了因方法名不存在导致的 **`AttributeError`**。
    - **文件**: hello_agents/agents/react_agent.py
        - **修复**: ReActAgent.add_tool 方法被重构，移除了原先手动实例化抽象 Tool 类的错误逻辑。现在它直接调用 self.tool_registry.register_tool(tool, auto_expand=True)，将工具展开的职责完全交给 ToolRegistry，使其行为与 SimpleAgent 保持一致。