### PR TITLE
fix:对llm.py中的think函数重复输出现象进行修改，原代码产生的生成器函数会将输出保存，直到被触发，这会导致外部进行逐chunk…

### DIFF
--- a/hello_agents/core/llm.py
+++ b/hello_agents/core/llm.py
@@ -309,7 +309,7 @@ class HelloAgentsLLM:
             for chunk in response:
                 content = chunk.choices[0].delta.content or ""
                 if content:
-                    print(content, end="", flush=True)
+                    #print(content, end="", flush=True),这行代码会导致重复输出模型的回答
                     yield content
             print()  # 在流式输出结束后换行
 


### PR DESCRIPTION
在MyLLM框架的think函数中，调用了print函数打印模型输出，但因为使用了yield导致think变为生成器函数，执行时"惰性触发"，即调用llm.think(messages)时，函数不会立即执行完所有内部代码，因为生成器函数的特性：
* 调用时只返回一个"生成器对象"（这里是response_stream)，不执行函数内部代码
* 当循环遍历生成器时，会一步步触发函数内部的代码，直到遇到yield就暂停，返回一个chunk

所以，当外部开始遍历response_strem时，才开始执行内部代码，由于think内部保留了print，同时外部print会再打印一次chunk，最终导致同一段文本被打印两次
而且因为外部的print("ModelScope Response:")在遍历之前，所以会先打印ModelScope Response：，然后打印内部think函数逐chunk的语句，最后逐chunk打印语句
但是为什么'正在使用自定义的ModelScope Provider'会在所有打印语句之前呢？
是因为我们在实例化MyLLM类的时候，会自动触发__init__方法，当判断provider=="modelscope"为true时，会执行该分支下的代码，其中就有print("正在使用自定义的 ModelScope Provider")
当我们按照原代码
```
print("ModelScope Response:")
for chunk in response_stream:     # chunk 已经是文本片段，可以直接使用
print(chunk, end="", flush=True)
```
使用时，会导致一个chunk被重复打印两次输出，也就是类似这样“你好你好我是我是”的情况出现
那么我们如何进行修改呢？
在main/hello_agents/core/llm.py找到think函数
找到以下代码
```
for chunk in response:
                content = chunk.choices[0].delta.content or ""
                if content:
                    print(content, end="", flush=True)
                    yield content
#将 print(content, end="", flush=True)去掉，变为下面的代码
for chunk in response:
                content = chunk.choices[0].delta.content or ""
                if content:
                    yield content
```

或者不改动框架，做如下改动
```
print("ModelScope Response:")
for chunk in response_stream:
    # chunk 已经是文本片段，可以直接使用
    print(chunk, end="", flush=True)
#改为
print("ModelScope Response:")
for chunk in response_stream:pass
```
这里只对函数think进行最小改动，因为如果修改文章中的代码，会比较麻烦，而且如果不知情的学习者调用了这个函数，解决起来会比较麻烦