### PR TITLE
fix: 修复MCPTool和ReActAgent的bug

### DIFF
--- a/hello_agents/agents/react_agent.py
+++ b/hello_agents/agents/react_agent.py
@@ -165,7 +165,7 @@ class ReActAgent(Agent):
             print(f"🎬 行动: {tool_name}[{tool_input}]")
             
             # 调用工具
-            observation = self.tool_registry.execute_tool(tool_name, tool_input)
+            observation = self._execute_tool_call(tool_name, tool_input)
             print(f"👀 观察: {observation}")
             
             # 更新历史
@@ -202,3 +202,26 @@ class ReActAgent(Agent):
         """解析行动输入"""
         match = re.match(r"\w+\[(.*)\]", action_text)
         return match.group(1) if match else ""
+
+    def _execute_tool_call(self, tool_name: str, parameters: str) -> str:
+        """执行工具调用"""
+        if not self.tool_registry:
+            return f"❌ 错误：未配置工具注册表"
+
+        try:
+            # 获取Tool对象
+            tool = self.tool_registry.get_tool(tool_name)
+            if not tool:
+                return f"❌ 错误：未找到工具 '{tool_name}'"
+
+            from json import loads, JSONDecodeError
+            try:
+                param_dict = loads(parameters)
+            except JSONDecodeError:
+                param_dict = {"input": parameters}
+
+            # 调用工具
+            return tool.run(param_dict)
+
+        except Exception as e:
+            return f"❌ 工具调用失败：{str(e)}"

--- a/hello_agents/agents/react_agent.py
+++ b/hello_agents/agents/react_agent.py
@@ -125,7 +125,10 @@ class ReActAgent(Agent):
             )
             
             # 调用LLM
-            messages = [{"role": "user", "content": prompt}]
+            messages = []
+            if self.system_prompt:
+                messages.append({"role": "system", "content": self.system_prompt})
+            messages.append({"role": "user", "content": prompt})
             response_text = self.llm.invoke(messages, **kwargs)
             
             if not response_text:

--- a/hello_agents/agents/react_agent.py
+++ b/hello_agents/agents/react_agent.py
@@ -85,7 +85,7 @@ class ReActAgent(Agent):
         # 设置提示词模板：用户自定义优先，否则使用默认模板
         self.prompt_template = custom_prompt if custom_prompt else DEFAULT_REACT_PROMPT
 
-    def add_tool(self, tool):
+    def add_tool(self, tool, auto_expand: bool = True):
         """
         添加工具到工具注册表
         支持MCP工具的自动展开
@@ -93,28 +93,7 @@ class ReActAgent(Agent):
         Args:
             tool: 工具实例(可以是普通Tool或MCPTool)
         """
-        # 检查是否是MCP工具
-        if hasattr(tool, 'auto_expand') and tool.auto_expand:
-            # MCP工具会自动展开为多个工具
-            if hasattr(tool, '_available_tools') and tool._available_tools:
-                for mcp_tool in tool._available_tools:
-                    # 创建包装工具
-                    from ..tools.base import Tool
-                    wrapped_tool = Tool(
-                        name=f"{tool.name}_{mcp_tool['name']}",
-                        description=mcp_tool.get('description', ''),
-                        func=lambda input_text, t=tool, tn=mcp_tool['name']: t.run({
-                            "action": "call_tool",
-                            "tool_name": tn,
-                            "arguments": {"input": input_text}
-                        })
-                    )
-                    self.tool_registry.register_tool(wrapped_tool)
-                print(f"✅ MCP工具 '{tool.name}' 已展开为 {len(tool._available_tools)} 个独立工具")
-            else:
-                self.tool_registry.register_tool(tool)
-        else:
-            self.tool_registry.register_tool(tool)
+        self.tool_registry.register_tool(tool, auto_expand=auto_expand)
 
     def run(self, input_text: str, **kwargs) -> str:
         """

--- a/hello_agents/agents/simple_agent.py
+++ b/hello_agents/agents/simple_agent.py
@@ -344,7 +344,7 @@ class SimpleAgent(Agent):
     def remove_tool(self, tool_name: str) -> bool:
         """移除工具（便利方法）"""
         if self.tool_registry:
-            return self.tool_registry.unregister_tool(tool_name)
+            return self.tool_registry.unregister(tool_name)
         return False
 
     def list_tools(self) -> list:

--- a/hello_agents/tools/builtin/mcp_wrapper_tool.py
+++ b/hello_agents/tools/builtin/mcp_wrapper_tool.py
@@ -97,7 +97,7 @@ class MCPWrappedTool(Tool):
         """
         return self._parameters
 
-    def run(self, params: Dict[str, Any]) -> str:
+    def run(self, parameters: Dict[str, Any]) -> str:
         """
         执行MCP工具
 
@@ -111,7 +111,7 @@ class MCPWrappedTool(Tool):
         mcp_params = {
             "action": "call_tool",
             "tool_name": self.mcp_tool_name,
-            "arguments": params
+            "arguments": parameters
         }
 
         # 调用父MCP工具

--- a/hello_agents/tools/builtin/memory_tool.py
+++ b/hello_agents/tools/builtin/memory_tool.py
@@ -23,8 +23,8 @@ class MemoryTool(Tool):
     def __init__(
         self,
         user_id: str = "default_user",
-        memory_config: MemoryConfig = None,
-        memory_types: List[str] = None,
+        memory_config: Optional[MemoryConfig] = None,
+        memory_types: Optional[List[str]] = None,
         expandable: bool = False
     ):
         super().__init__(
@@ -144,8 +144,8 @@ class MemoryTool(Tool):
         content: str = "",
         memory_type: str = "working",
         importance: float = 0.5,
-        file_path: str = None,
-        modality: str = None
+        file_path: Optional[str] = None,
+        modality: Optional[str] = None
     ) -> str:
         """添加记忆
 
@@ -207,7 +207,7 @@ class MemoryTool(Tool):
         self,
         query: str,
         limit: int = 5,
-        memory_type: str = None,
+        memory_type: Optional[str] = None,
         min_importance: float = 0.1
     ) -> str:
         """搜索记忆
@@ -392,13 +392,13 @@ class MemoryTool(Tool):
             )
 
     @tool_action("memory_update", "更新已存在的记忆")
-    def _update_memory(self, memory_id: str, content: str = None, importance: float = None) -> str:
+    def _update_memory(self, memory_id: str, content: Optional[str] = None, importance: float = 0.7) -> str:
         """更新记忆
 
         Args:
             memory_id: 要更新的记忆ID
             content: 新的记忆内容
-            importance: 新的重要性分数
+            importance: 新的重要性分数, 默认0.7
 
         Returns:
             执行结果

--- a/hello_agents/tools/builtin/protocol_tools.py
+++ b/hello_agents/tools/builtin/protocol_tools.py
@@ -129,7 +129,8 @@ class MCPTool(Tool):
 
         super().__init__(
             name=name,
-            description=description
+            description=description,
+            expandable=self.auto_expand
         )
 
     def _prepare_env(self,

--- a/hello_agents/tools/builtin/protocol_tools.py
+++ b/hello_agents/tools/builtin/protocol_tools.py
@@ -537,7 +537,7 @@ class A2ATool(Tool):
     官方仓库: https://github.com/a2aproject/a2a-python
     """
     
-    def __init__(self, agent_url: str, name: str = "a2a", description: str = None):
+    def __init__(self, agent_url: str, name: str = "a2a", description: Optional[str] = None):
         """
         初始化 A2A 工具
 
@@ -663,8 +663,8 @@ class ANPTool(Tool):
     注意：这是概念性实现，不需要额外依赖
     详见文档: docs/chapter10/ANP_CONCEPTS.md
     """
-    
-    def __init__(self, name: str = "anp", description: str = None, discovery=None, network=None):
+
+    def __init__(self, name: str = "anp", description: Optional[str] = None, discovery=None, network=None):
         """初始化 ANP 工具
 
         Args:

--- a/hello_agents/tools/registry.py
+++ b/hello_agents/tools/registry.py
@@ -62,16 +62,18 @@ class ToolRegistry:
         }
         print(f"✅ 工具 '{name}' 已注册。")
 
-    def unregister(self, name: str):
+    def unregister(self, name: str) -> bool:
         """注销工具"""
         if name in self._tools:
             del self._tools[name]
             print(f"🗑️ 工具 '{name}' 已注销。")
-        elif name in self._functions:
+            return True
+        if name in self._functions:
             del self._functions[name]
             print(f"🗑️ 工具 '{name}' 已注销。")
-        else:
-            print(f"⚠️ 工具 '{name}' 不存在。")
+            return True
+        print(f"⚠️ 工具 '{name}' 不存在。")
+        return False
 
     def get_tool(self, name: str) -> Optional[Tool]:
         """获取Tool对象"""


### PR DESCRIPTION
1. ReActAgent初始化的system_prompt未传递给llm，导致信息缺失
2. ReActAgent 的`add_tool`方法中，无法创建MCPTool的包装工具，导致多功能工具无法使用
3. ToolRegistry 的`execute_tool`方法中，自动给参数包裹了一层input，导致传递给MCPTool的参数格式错误
4. 一些其他问题