### PR TITLE
fix:实例化RAGTool时，删除错误的多余参数

### DIFF
--- a/examples/chapter08_memory_rag.py
+++ b/examples/chapter08_memory_rag.py
@@ -99,9 +99,7 @@ def demo_simple_agent_with_rag():
 
     # 创建RAG工具 - 使用本地嵌入（推荐）
     rag_tool = RAGTool(
-        knowledge_base_path="./demo_knowledge_base",
-        embedding_model="local",  # 使用本地sentence-transformers，避免网络超时
-        retrieval_strategy="vector"
+        knowledge_base_path="./demo_knowledge_base"
     )
 
     # 创建工具注册表


### PR DESCRIPTION
1.demo_simple_agent_with_rag方法调用创建RAG工具时，创建RAGTool，参数多余导致代码失败
