### PR TITLE
添加的 Ollama Embedding 支持功能

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,12 +68,23 @@ NEO4J_MAX_CONNECTION_POOL_SIZE=50
 NEO4J_CONNECTION_TIMEOUT=60
 
 # ==========================
-# 嵌入（Embedding）配置示例 - 可从阿里云控制台获取：https://dashscope.aliyun.com/
+# 嵌入（Embedding）配置示例
 # ==========================
-# - 若为空，dashscope 默认 text-embedding-v3；local 默认 sentence-transformers/all-MiniLM-L6-v2
+# 模型类型: dashscope | ollama | local | tfidf
+# - dashscope: 阿里云通义千问，可从阿里云控制台获取：https://dashscope.aliyun.com/
+# - ollama: 本地/远程 Ollama 服务，需要提供 EMBED_BASE_URL
+# - local: 本地 sentence-transformers 模型
+# - tfidf: TF-IDF 兜底方案
 EMBED_MODEL_TYPE=dashscope
+# 模型名称
+# - dashscope 默认: text-embedding-v3
+# - ollama 默认: qwen3-embedding:0.6b（或其他已拉取的 embedding 模型）
+# - local 默认: sentence-transformers/all-MiniLM-L6-v2
 EMBED_MODEL_NAME=
+# API密钥（dashscope 必需，ollama 可选）
 EMBED_API_KEY=
+# API Base URL（ollama 必需，其他可选）
+# - ollama 示例: http://localhost:11434/api
 EMBED_BASE_URL=
 
 # ================================


### PR DESCRIPTION
# Ollama Embedding 支持

## 概述

本文档描述了为 HelloAgents 项目添加的 Ollama Embedding 支持功能。该功能允许用户使用本地或远程 Ollama 服务作为文本嵌入向量生成器。

## 功能描述

### 新增的 Embedding 类型

在 `EMBED_MODEL_TYPE` 环境变量中新增了 `ollama` 选项，现有的嵌入类型包括：

- `dashscope` - 阿里云通义千问（默认）
- `ollama` - Ollama 本地/远程服务（新增）
- `local` - 本地 sentence-transformers 模型
- `tfidf` - TF-IDF 兜底方案

### Ollama API 特性

Ollama Embedding API 与其他提供商相比有以下特点：

1. **双接口支持**
   - 批量接口 `/api/embed`（v0.2.0+）：一次请求处理多个文本
   - 单条接口 `/api/embeddings`：逐个处理文本
   - 实现会优先尝试批量接口，不可用时自动降级为单条循环调用

2. **批量接口格式**（v0.2.0+）
   - Payload：`{"model": "model_name", "input": ["text1", "text2", ...]}`
   - 响应：`{"embeddings": [[...], [...]]}`

3. **单条接口格式**（降级方案）
   - Payload：`{"model": "model_name", "prompt": "text"}`
   - 响应：`{"embedding": [...]}`

4. **自动降级机制**
   - 首次批量调用时探测批量接口是否可用
   - 缓存探测结果，后续直接使用可用接口
   - 批量接口失效时自动降级到单条接口

5. **Base URL 要求**
   - 必须提供 `EMBED_BASE_URL` 环境变量
   - URL 应指向 Ollama 服务的 `/api` 端点

## 配置方法

### 环境变量配置

在 `.env` 文件中添加以下配置：

```bash
# 设置嵌入模型类型为 ollama
EMBED_MODEL_TYPE=ollama

# 设置模型名称（默认 qwen3-embedding:0.6b）
EMBED_MODEL_NAME=qwen3-embedding:0.6b

# Ollama 服务地址（必需）
EMBED_BASE_URL=http://localhost:11434/api
```

### 支持的 Ollama 模型

常用的 Ollama embedding 模型：

- `qwen3-embedding:0.6b` - 默认推荐（通义千问轻量级 embedding 模型）
- `nomic-embed-text`
- `mxbai-embed-large`
- `all-minilm`

拉取模型示例：
```bash
ollama pull qwen3-embedding:0.6b
```

## 代码实现

### 新增类：OllamaEmbedding

位置：`hello_agents/memory/embedding.py`

```python
class OllamaEmbedding(EmbeddingModel):
    """Ollama Embedding API

    行为：
    - 优先使用批量接口 /api/embed（v0.2.0+ 支持）
    - 如果批量接口不可用，降级为单条接口 /api/embeddings 循环调用
    - 批量接口返回：{"embeddings": [[...], [...]]}
    - 单条接口返回：{"embedding": [...]}
    """
```

### 方法说明

- `_encode_batch(inputs)` - 使用 `/api/embed` 批量接口
- `_encode_single(inputs)` - 使用 `/api/embeddings` 单条接口
- `encode(texts)` - 主入口，自动选择接口并处理降级

### 工厂函数更新

`create_embedding_model()` 函数新增 `ollama` 分支支持。

### 默认模型配置

`_build_embedder()` 函数更新，为 `ollama` 类型设置默认模型 `nomic-embed-text`。

## 使用示例

### Python 代码示例

```python
from hello_agents.memory.embedding import get_text_embedder

# 确保环境变量已设置
# EMBED_MODEL_TYPE=ollama
# EMBED_BASE_URL=http://localhost:11434/api

# 获取 embedder
embedder = get_text_embedder()

# 单个文本嵌入
text = "Hello, world!"
embedding = embedder.encode(text)
print(f"Dimension: {len(embedding)}")

# 批量文本嵌入（内部循环调用）
texts = ["Hello", "World", "How are you?"]
embeddings = embedder.encode(texts)
print(f"Count: {len(embeddings)}")
```

### 本地 Ollama 服务部署

```bash
# 安装 Ollama
curl -fsSL https://ollama.com/install.sh | sh

# 拉取 embedding 模型
ollama pull nomic-embed-text

# 启动服务（默认运行在 11434 端口）
ollama serve
```

### 远程 Ollama 服务

如果使用远程 Ollama 服务（如通过 tunnel 暴露的本地服务）：

```bash
# 配置远程服务 URL
EMBED_BASE_URL=https://your-remote-url.cnb.run/api
```

## 技术细节

### API 端点处理

代码会自动处理 URL 格式：
- 如果 `EMBED_BASE_URL` 不以 `/api` 结尾，会自动添加
- 批量接口：`{base_url}/embed`
- 单条接口：`{base_url}/embeddings`

### 批量处理与自动降级

1. **探测阶段**（首次批量调用）
   - 尝试调用 `/api/embed` 批量接口
   - 成功则缓存 `_batch_supported = True`
   - 失败则缓存 `_batch_supported = False`

2. **正常调用**
   - 若 `_batch_supported = True`：直接使用批量接口
   - 若 `_batch_supported = False`：使用单条接口循环调用

3. **动态降级**
   - 批量接口突然失效时，自动切换到单条接口
   - 更新缓存状态，避免重复尝试失败的批量接口

```python
# 批量接口调用
payload = {"model": self.model_name, "input": inputs}
resp = requests.post(f"{base_url}/embed", json=payload)

# 单条接口调用（降级）
for text in inputs:
    payload = {"model": self.model_name, "prompt": text}
    resp = requests.post(f"{base_url}/embeddings", json=payload)
```

### 错误处理

- 缺少 `base_url` 时抛出 `ValueError`
- API 调用失败时抛出 `RuntimeError`
- 响应格式不匹配时抛出 `RuntimeError`

## 相关文件

- `.env.example` - 环境变量配置示例
- `hello_agents/memory/embedding.py` - 核心实现
- `plan.txt` - 需求文档

## 依赖

- `requests` - HTTP 请求库（项目已有依赖）

## 兼容性

- 与现有的 `EmbeddingModel` 接口完全兼容
- 支持 `get_text_embedder()` 全局单例
- 支持 `get_dimension()` 维度查询
- 支持 `refresh_embedder()` 动态切换

## 未来改进

- [ ] 添加请求缓存以减少重复调用
- [ ] 支持自定义超时时间
- [ ] 添加连接池支持
