### PR TITLE
fix: 优化当 provider 包含大写字母（如“Qwen”）且未提供 base_url 时支持自动检测

### DIFF
--- a/hello_agents/core/llm.py
+++ b/hello_agents/core/llm.py
@@ -66,10 +66,9 @@ class HelloAgentsLLM:
 
         # 自动检测provider或使用指定的provider
         requested_provider = (provider or "").lower() if provider else None
-        self.provider = provider or self._auto_detect_provider(api_key, base_url)
+        self.provider = requested_provider or self._auto_detect_provider(api_key, base_url)
 
         if requested_provider == "custom":
-            self.provider = "custom"
             self.api_key = api_key or os.getenv("LLM_API_KEY")
             self.base_url = base_url or os.getenv("LLM_BASE_URL")
         else:


### PR DESCRIPTION
当 provider 包含大写字母（如“Qwen”）且未提供 base_url 时会抛出异常，对其进行优化使其支持自动检测。
