### PR TITLE
refactor: 统一 Agent.add_tool 方法，将工具展开逻辑移至

### DIFF
--- a/hello_agents/agents/function_call_agent.py
+++ b/hello_agents/agents/function_call_agent.py
@@ -339,23 +339,20 @@ class FunctionCallAgent(Agent):
         self.add_message(Message(final_response, "assistant"))
         return final_response
 
-    def add_tool(self, tool) -> None:
-        """便捷方法：将工具注册到当前Agent"""
+    def add_tool(self, tool, auto_expand: bool = True) -> None:
+        """
+        添加工具到Agent（便利方法）
+
+        Args:
+            tool: Tool对象
+            auto_expand: 是否自动展开可展开的工具（默认True）
+        """
         if not self.tool_registry:
             from ..tools.registry import ToolRegistry
-
             self.tool_registry = ToolRegistry()
             self.enable_tool_calling = True
 
-        if hasattr(tool, "auto_expand") and getattr(tool, "auto_expand"):
-            expanded_tools = tool.get_expanded_tools()
-            if expanded_tools:
-                for expanded_tool in expanded_tools:
-                    self.tool_registry.register_tool(expanded_tool)
-                print(f"✅ MCP工具 '{tool.name}' 已展开为 {len(expanded_tools)} 个独立工具")
-                return
-
-        self.tool_registry.register_tool(tool)
+        self.tool_registry.register_tool(tool, auto_expand=auto_expand)
 
     def remove_tool(self, tool_name: str) -> bool:
         if self.tool_registry:

--- a/hello_agents/agents/react_agent.py
+++ b/hello_agents/agents/react_agent.py
@@ -85,36 +85,15 @@ class ReActAgent(Agent):
         # 设置提示词模板：用户自定义优先，否则使用默认模板
         self.prompt_template = custom_prompt if custom_prompt else DEFAULT_REACT_PROMPT
 
-    def add_tool(self, tool):
+    def add_tool(self, tool, auto_expand: bool = True) -> None:
         """
         添加工具到工具注册表
-        支持MCP工具的自动展开
 
         Args:
             tool: 工具实例(可以是普通Tool或MCPTool)
+            auto_expand: 是否自动展开可展开的工具（默认True）
         """
-        # 检查是否是MCP工具
-        if hasattr(tool, 'auto_expand') and tool.auto_expand:
-            # MCP工具会自动展开为多个工具
-            if hasattr(tool, '_available_tools') and tool._available_tools:
-                for mcp_tool in tool._available_tools:
-                    # 创建包装工具
-                    from ..tools.base import Tool
-                    wrapped_tool = Tool(
-                        name=f"{tool.name}_{mcp_tool['name']}",
-                        description=mcp_tool.get('description', ''),
-                        func=lambda input_text, t=tool, tn=mcp_tool['name']: t.run({
-                            "action": "call_tool",
-                            "tool_name": tn,
-                            "arguments": {"input": input_text}
-                        })
-                    )
-                    self.tool_registry.register_tool(wrapped_tool)
-                print(f"✅ MCP工具 '{tool.name}' 已展开为 {len(tool._available_tools)} 个独立工具")
-            else:
-                self.tool_registry.register_tool(tool)
-        else:
-            self.tool_registry.register_tool(tool)
+        self.tool_registry.register_tool(tool, auto_expand=auto_expand)
 
     def run(self, input_text: str, **kwargs) -> str:
         """

--- a/hello_agents/tools/registry.py
+++ b/hello_agents/tools/registry.py
@@ -24,18 +24,34 @@ class ToolRegistry:
         Args:
             tool: Tool实例
             auto_expand: 是否自动展开可展开的工具（默认True）
+
+        支持两种工具展开方式：
+        1. MCP工具：通过 auto_expand 属性标记
+        2. 普通可展开工具：通过 expandable 属性标记
         """
-        # 检查工具是否可展开
-        if auto_expand and hasattr(tool, 'expandable') and tool.expandable:
-            expanded_tools = tool.get_expanded_tools()
-            if expanded_tools:
-                # 注册所有展开的子工具
-                for sub_tool in expanded_tools:
-                    if sub_tool.name in self._tools:
-                        print(f"⚠️ 警告：工具 '{sub_tool.name}' 已存在，将被覆盖。")
-                    self._tools[sub_tool.name] = sub_tool
-                print(f"✅ 工具 '{tool.name}' 已展开为 {len(expanded_tools)} 个独立工具")
-                return
+        expanded_tools = None
+        tool_type = "工具"
+
+        # 检查是否需要展开工具
+        if auto_expand:
+            # 处理 MCP 工具（使用 auto_expand 属性）
+            if hasattr(tool, 'auto_expand') and tool.auto_expand:
+                expanded_tools = tool.get_expanded_tools()
+                if expanded_tools:
+                    tool_type = "MCP工具"
+
+            # 处理普通可展开工具（使用 expandable 属性）
+            if expanded_tools is None and hasattr(tool, 'expandable') and tool.expandable:
+                expanded_tools = tool.get_expanded_tools()
+
+        # 注册展开的子工具
+        if expanded_tools:
+            for sub_tool in expanded_tools:
+                if sub_tool.name in self._tools:
+                    print(f"⚠️ 警告：工具 '{sub_tool.name}' 已存在，将被覆盖。")
+                self._tools[sub_tool.name] = sub_tool
+            print(f"✅ {tool_type} '{tool.name}' 已展开为 {len(expanded_tools)} 个独立工具")
+            return
 
         # 普通工具或不展开的工具
         if tool.name in self._tools:


### PR DESCRIPTION
   Fixes #52
  ToolRegistry

  - 增强 ToolRegistry.register_tool 支持 MCP 工具展开
  - 简化 ReActAgent.add_tool 实现
  - 统一 FunctionCallAgent.add_tool 与 SimpleAgent 一致