### PR TITLE
Refactor context builder and update memory tools

### DIFF
--- a/hello_agents/context/builder.py
+++ b/hello_agents/context/builder.py
@@ -140,12 +140,13 @@ class ContextBuilder:
         if self.memory_tool:
             try:
                 # 搜索任务状态相关记忆
-                state_results = self.memory_tool.execute(
-                    "search",
-                    query="(任务状态 OR 子目标 OR 结论 OR 阻塞)",
-                    min_importance=0.7,
-                    limit=5
-                )
+                state_results = self.memory_tool.run({
+                    "action": "search",
+                    "query": "(任务状态 OR 子目标 OR 结论 OR 阻塞)",
+                    "min_importance": 0.7,
+                    "limit": 5
+                })
+
                 if state_results and "未找到" not in state_results:
                     packets.append(ContextPacket(
                         content=state_results,
@@ -153,11 +154,12 @@ class ContextBuilder:
                     ))
                 
                 # 搜索与当前查询相关的记忆
-                related_results = self.memory_tool.execute(
-                    "search",
-                    query=user_query,
-                    limit=5
-                )
+                related_results = self.memory_tool.run({
+                    "action": "search",
+                    "query": user_query,
+                    "limit": 5
+                })
+
                 if related_results and "未找到" not in related_results:
                     packets.append(ContextPacket(
                         content=related_results,

--- a/hello_agents/core/llm.py
+++ b/hello_agents/core/llm.py
@@ -318,19 +318,29 @@ class HelloAgentsLLM:
             raise HelloAgentsException(f"LLM调用失败: {str(e)}")
 
     def invoke(self, messages: list[dict[str, str]], **kwargs) -> str:
-        """
-        非流式调用LLM，返回完整响应。
-        适用于不需要流式输出的场景。
-        """
         try:
-            response = self._client.chat.completions.create(
-                model=self.model,
-                messages=messages,
-                temperature=kwargs.get('temperature', self.temperature),
-                max_tokens=kwargs.get('max_tokens', self.max_tokens),
-                **{k: v for k, v in kwargs.items() if k not in ['temperature', 'max_tokens']}
-            )
+            params = {
+                "model": self.model,
+                "messages": messages,
+                "temperature": kwargs.get("temperature", self.temperature),
+            }
+
+            # 只有当 max_tokens 不是 None 时才添加
+            max_tokens_value = kwargs.get("max_tokens", self.max_tokens)
+            if max_tokens_value is not None:
+                params["max_tokens"] = max_tokens_value
+
+            # 其他额外参数
+            extra_params = {
+                k: v for k, v in kwargs.items()
+                if k not in ["temperature", "max_tokens"]
+            }
+            params.update(extra_params)
+
+            response = self._client.chat.completions.create(**params)
+
             return response.choices[0].message.content
+
         except Exception as e:
             raise HelloAgentsException(f"LLM调用失败: {str(e)}")
 

--- a/hello_agents/tools/builtin/memory_tool.py
+++ b/hello_agents/tools/builtin/memory_tool.py
@@ -64,6 +64,7 @@ class MemoryTool(Tool):
 
         action = parameters.get("action")
 
+
         # 根据action调用对应的方法，传入提取的参数
         if action == "add":
             return self._add_memory(

--- a/hello_agents/tools/builtin/note_tool.py
+++ b/hello_agents/tools/builtin/note_tool.py
@@ -269,9 +269,9 @@ class NoteTool(Tool):
             ),
             ToolParameter(
                 name="tags",
-                type="array",
+                type="string",
                 description="标签列表（可选）",
-                required=False
+                required=False,
             ),
             ToolParameter(
                 name="note_id",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# 开发与测试（含 evaluation 链所需依赖，便于直接运行 pytest）
+dev = [
+    "pytest>=7.0.0",
+    "huggingface_hub>=0.20.0,<1.0.0",
+]
+
 # 搜索功能依赖
 search = [
     "tavily-python>=0.7.12",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# HelloAgents 测试包

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""pytest 共享 fixture：Mock LLM 等"""
+
+from typing import Iterator
+import pytest
+
+
+class MockLLM:
+    """用于测试的假 LLM，不发起真实 API 调用。"""
+
+    def __init__(self, response: str = "Mock response", provider: str = "mock"):
+        self.response = response
+        self.provider = provider
+        self.model = "mock-model"
+
+    def invoke(self, messages: list, **kwargs) -> str:
+        return self.response
+
+    def stream_invoke(self, messages: list, **kwargs) -> Iterator[str]:
+        for char in self.response:
+            yield char
+
+
+@pytest.fixture
+def mock_llm() -> MockLLM:
+    """提供 MockLLM 实例。"""
+    return MockLLM(response="Hello from mock LLM.")

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,31 @@
+"""测试包与主要导出能否正常导入（使用子模块导入，避免拉取可选依赖）。"""
+
+import pytest
+
+
+def test_import_version():
+    from hello_agents.version import __version__
+    assert __version__ and isinstance(__version__, str)
+
+
+def test_import_core():
+    from hello_agents.core.config import Config
+    from hello_agents.core.message import Message
+    from hello_agents.core.exceptions import HelloAgentsException
+    from hello_agents.core.llm import HelloAgentsLLM
+    assert Config is not None
+    assert Message is not None
+    assert HelloAgentsException is not None
+    assert HelloAgentsLLM is not None
+
+
+def test_import_simple_agent():
+    from hello_agents.agents.simple_agent import SimpleAgent
+    assert SimpleAgent is not None
+
+
+def test_import_tools():
+    from hello_agents.tools.registry import ToolRegistry
+    from hello_agents.tools.builtin.calculator import CalculatorTool
+    assert ToolRegistry is not None
+    assert CalculatorTool is not None

--- a/tests/test_simple_agent.py
+++ b/tests/test_simple_agent.py
@@ -1,0 +1,26 @@
+"""测试 SimpleAgent（使用 Mock LLM，不调用真实 API）。"""
+
+import pytest
+from hello_agents.agents.simple_agent import SimpleAgent
+
+
+def test_simple_agent_run(mock_llm):
+    agent = SimpleAgent(name="TestAgent", llm=mock_llm, system_prompt="You are helpful.")
+    out = agent.run("Hello")
+    assert "Hello from mock LLM" in out or out == "Hello from mock LLM."
+
+
+def test_simple_agent_stream_run(mock_llm):
+    agent = SimpleAgent(name="TestAgent", llm=mock_llm)
+    chunks = list(agent.stream_run("Hi"))
+    assert len(chunks) > 0
+    assert "".join(chunks) == "Hello from mock LLM."
+
+
+def test_simple_agent_history(mock_llm):
+    agent = SimpleAgent(name="TestAgent", llm=mock_llm)
+    agent.run("Q1")
+    history = agent.get_history()
+    assert len(history) >= 1
+    agent.clear_history()
+    assert len(agent.get_history()) == 0

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,60 @@
+"""测试工具注册表与内置计算器。"""
+
+import pytest
+from hello_agents.tools.registry import ToolRegistry
+from hello_agents.tools.builtin.calculator import CalculatorTool
+
+
+class TestToolRegistry:
+    def test_register_and_get_tool(self):
+        reg = ToolRegistry()
+        calc = CalculatorTool()
+        reg.register_tool(calc, auto_expand=True)
+        assert reg.get_tool(calc.name) is calc
+
+    def test_execute_tool_by_name(self):
+        reg = ToolRegistry()
+        reg.register_tool(CalculatorTool(), auto_expand=True)
+        out = reg.execute_tool("python_calculator", "2 + 3")
+        assert "5" in out
+
+    def test_register_function(self):
+        reg = ToolRegistry()
+
+        def echo(x: str) -> str:
+            return x
+
+        reg.register_function("echo", "Echo input", echo)
+        assert reg.get_function("echo") is echo
+        assert reg.execute_tool("echo", "hi") == "hi"
+
+    def test_get_tools_description(self):
+        reg = ToolRegistry()
+        reg.register_tool(CalculatorTool(), auto_expand=True)
+        desc = reg.get_tools_description()
+        assert "python_calculator" in desc or "计算" in desc
+
+    def test_unregister(self):
+        reg = ToolRegistry()
+        reg.register_function("dummy", "Dummy", lambda x: x)
+        reg.unregister("dummy")
+        assert reg.get_function("dummy") is None
+
+
+class TestCalculatorTool:
+    def test_run_with_input(self):
+        calc = CalculatorTool()
+        assert calc.run({"input": "1 + 1"}) == "2"
+
+    def test_run_with_expression(self):
+        calc = CalculatorTool()
+        assert calc.run({"expression": "3 * 4"}) == "12"
+
+    def test_run_empty_fails(self):
+        calc = CalculatorTool()
+        out = calc.run({"input": ""})
+        assert "错误" in out or "空" in out
+
+    def test_math_functions(self):
+        calc = CalculatorTool()
+        assert "2" in calc.run({"input": "sqrt(4)"})


### PR DESCRIPTION
1）hello_agents/context/builder.py
目的：

让 ContextBuilder 在收集上下文时调用 MemoryTool 的统一入口 run({...})，避免混用旧的 execute("search", ...) 调用方式，增强工具接口一致性。

具体改动：把两处记忆检索从：

self.memory_tool.execute("search", query=..., min_importance=..., limit=...)
改成：

self.memory_tool.run({"action": "search", "query": ..., "min_importance": ..., "limit": ...})

影响范围是 _gather() 中两类记忆：

“任务状态/子目标/结论/阻塞”等高重要度记忆（min_importance=0.7，limit=5）

与当前 user_query 直接相关的记忆（limit=5）ContextBuilder 不再依赖 MemoryTool 的“自定义 execute 方法签名”，而是走 tool 标准 run(parameters) 路径。

2）hello_agents/core/llm.py目的

让 invoke() 在调用 OpenAI chat completion 时更稳健地组装参数，尤其处理 max_tokens=None 的情况，避免把 None 作为参数传入导致不兼容/异常。

具体改动

原逻辑：直接在 .create() 里传 max_tokens=kwargs.get(..., self.max_tokens)，以及用字典推导补充额外参数。

新逻辑：先构造 params：

固定放入：model/messages/temperature

仅当 max_tokens_value is not None 时才把 max_tokens 写进 params

其他参数（除 temperature/max_tokens）合并进 params

最后：self._client.chat.completions.create(**params)
3）hello_agents/tools/builtin/note_tool.py
目的

修正 get_parameters() 里 tags 参数的类型定义，使 ToolParameter 描述更一致/可用。

具体改动：
在 tags 参数处：

删除/修正了重复或冲突的 type 字段（原本同时出现 type="array" 和 type="string" 这种不一致写法）

4）新增test测试包
新增基础smoke tests,确保核心模块可以导入，Simpleagent可以在mock LLM下运行，Registry注册执行正常更改context builder 内原有execute问题导致与run方法不兼容问题