### PR TITLE
Refactor paragraph start condition in pipeline.py

### DIFF
--- a/hello_agents/memory/rag/pipeline.py
+++ b/hello_agents/memory/rag/pipeline.py
@@ -162,8 +162,7 @@ def _post_process_pdf_text(text: str) -> str:
         if (line.startswith('#') or  # 标题
             line.endswith('：') or   # 中文冒号结尾
             line.endswith(':') or    # 英文冒号结尾
-            len(line) > 150 or       # 长句通常是段落开始
-            not current_paragraph):  # 第一行
+            len(line) > 150):  # 长句通常是段落开始
             
             # 保存当前段落
             if current_paragraph:


### PR DESCRIPTION
在rag/pipeline.py的_post_process_pdf_text方法中的第三步：重新组织段落中
需删除not current_paragraph这一条件，否则无法进入else的判断逻辑中