### PR TITLE
update simple_agent

### DIFF
--- a/hello_agents/agents/simple_agent.py
+++ b/hello_agents/agents/simple_agent.py
@@ -292,14 +292,16 @@ class SimpleAgent(Agent):
                 tool_results = []
                 clean_response = response
 
+                # 构建包含工具结果的消息
+                messages.append({"role": "assistant", "content": clean_response})
+
                 for call in tool_calls:
                     result = self._execute_tool_call(call['tool_name'], call['parameters'])
                     tool_results.append(result)
                     # 从响应中移除工具调用标记
                     clean_response = clean_response.replace(call['original'], "")
 
-                # 构建包含工具结果的消息
-                messages.append({"role": "assistant", "content": clean_response})
+
 
                 # 添加工具结果
                 tool_results_text = "\n\n".join(tool_results)


### PR DESCRIPTION
 clean_response = response  # 293行：初始化

  for call in tool_calls:     # 295行：循环移除工具调用标记
      ...
      clean_response = clean_response.replace(call['original'], "")  # 每次循环都覆盖

  messages.append({"role": "assistant", "content": clean_response})  # 302行：此时 clean_response 可能已为空

  如果 LLM 返回的内容主要是工具调用标记，循环结束后 clean_response 就变成了空字符串，导致 assistant 消息内容为空。

  正确做法：

  应该在第293行之后、循环之前先保存原始响应：

  tool_results = []
  clean_response = response

  # 先添加原始 assistant 消息
  messages.append({"role": "assistant", "content": clean_response})

  for call in tool_calls:
      result = self._execute_tool_call(call['tool_name'], call['parameters'])
      tool_results.append(result)
      clean_response = clean_response.replace(call['original'], "")  # 这里再清理