### PR TITLE
fix: generate valid schemas for array tool parameters

### DIFF
--- a/hello_agents/core/agent.py
+++ b/hello_agents/core/agent.py
@@ -520,38 +520,20 @@ class Agent(ABC):
 
         # 1. 处理 Tool 对象
         for tool in self.tool_registry.get_all_tools():
-            properties: Dict[str, Any] = {}
-            required: List[str] = []
-
             try:
-                parameters = tool.get_parameters()
+                schemas.append(tool.to_openai_schema())
             except Exception:
-                parameters = []
-
-            for param in parameters:
-                properties[param.name] = {
-                    "type": self._map_parameter_type(param.type),
-                    "description": param.description or ""
-                }
-                if param.default is not None:
-                    properties[param.name]["default"] = param.default
-                if getattr(param, "required", True):
-                    required.append(param.name)
-
-            schema: Dict[str, Any] = {
-                "type": "function",
-                "function": {
-                    "name": tool.name,
-                    "description": tool.description or "",
-                    "parameters": {
-                        "type": "object",
-                        "properties": properties
+                schemas.append({
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description or "",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {}
+                        }
                     }
-                }
-            }
-            if required:
-                schema["function"]["parameters"]["required"] = required
-            schemas.append(schema)
+                })
 
         # 2. 处理函数工具
         function_map = getattr(self.tool_registry, "_functions", {})
@@ -575,21 +557,6 @@ class Agent(ABC):
             })
 
         return schemas
-
-    @staticmethod
-    def _map_parameter_type(param_type: str) -> str:
-        """将工具参数类型映射为 JSON Schema 允许的类型
-
-        Args:
-            param_type: 工具参数类型
-
-        Returns:
-            JSON Schema 类型
-        """
-        normalized = (param_type or "").lower()
-        if normalized in {"string", "number", "integer", "boolean", "array", "object"}:
-            return normalized
-        return "string"
 
     def _convert_parameter_types(self, tool_name: str, param_dict: Dict[str, Any]) -> Dict[str, Any]:
         """根据工具定义转换参数类型

--- a/hello_agents/tools/base.py
+++ b/hello_agents/tools/base.py
@@ -45,6 +45,39 @@ class ToolParameter(BaseModel):
     description: str
     required: bool = True
     default: Any = None
+    enum: Optional[List[Any]] = None
+    items: Optional[Dict[str, Any]] = None
+    properties: Optional[Dict[str, Any]] = None
+    additional_properties: Optional[Any] = None
+
+    def to_openai_schema(self) -> Dict[str, Any]:
+        """转换为单个参数的 OpenAI JSON Schema"""
+        param_type = (self.type or "").lower()
+        if param_type not in {"string", "number", "integer", "boolean", "array", "object"}:
+            param_type = "string"
+
+        description = self.description or ""
+        if self.default is not None:
+            description = f"{description} (默认: {self.default})".strip()
+
+        schema: Dict[str, Any] = {
+            "type": param_type,
+            "description": description
+        }
+
+        if self.enum:
+            schema["enum"] = self.enum
+
+        if param_type == "array":
+            schema["items"] = self.items or {"type": "string"}
+
+        if param_type == "object" and self.properties:
+            schema["properties"] = self.properties
+
+        if param_type == "object" and self.additional_properties is not None:
+            schema["additionalProperties"] = self.additional_properties
+
+        return schema
 
 
 class Tool(ABC):
@@ -251,21 +284,7 @@ class Tool(ABC):
         required = []
 
         for param in parameters:
-            # 基础属性定义
-            prop = {
-                "type": param.type,
-                "description": param.description
-            }
-
-            # 如果有默认值，添加到描述中（OpenAI schema 不支持 default 字段）
-            if param.default is not None:
-                prop["description"] = f"{param.description} (默认: {param.default})"
-
-            # 如果是数组类型，添加 items 定义
-            if param.type == "array":
-                prop["items"] = {"type": "string"}  # 默认字符串数组
-
-            properties[param.name] = prop
+            properties[param.name] = param.to_openai_schema()
 
             # 收集必需参数
             if param.required:

--- a/hello_agents/tools/builtin/file_tools.py
+++ b/hello_agents/tools/builtin/file_tools.py
@@ -629,7 +629,21 @@ class MultiEditTool(Tool):
                 name="edits",
                 type="array",
                 description="替换列表，每项包含 old_string 和 new_string",
-                required=True
+                required=True,
+                items={
+                    "type": "object",
+                    "properties": {
+                        "old_string": {
+                            "type": "string",
+                            "description": "要替换的原始文本，必须唯一匹配"
+                        },
+                        "new_string": {
+                            "type": "string",
+                            "description": "替换后的文本"
+                        }
+                    },
+                    "required": ["old_string", "new_string"]
+                }
             ),
             ToolParameter(
                 name="file_mtime_ms",
@@ -759,4 +773,3 @@ class MultiEditTool(Tool):
         if os.path.isabs(path):
             return Path(path)
         return self.working_dir / path
-

--- a/hello_agents/tools/builtin/todowrite_tool.py
+++ b/hello_agents/tools/builtin/todowrite_tool.py
@@ -161,14 +161,38 @@ class TodoWriteTool(Tool):
 - 最多 1 个任务可以标记为 in_progress
 - 每次提交完整列表（声明式）""",
                 required=False,
-                default=[]
+                default=[],
+                items={
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "string",
+                            "description": "任务内容"
+                        },
+                        "status": {
+                            "type": "string",
+                            "description": "任务状态",
+                            "enum": ["pending", "in_progress", "completed"]
+                        },
+                        "created_at": {
+                            "type": "string",
+                            "description": "创建时间（ISO 8601，可选）"
+                        },
+                        "updated_at": {
+                            "type": "string",
+                            "description": "更新时间（ISO 8601，可选）"
+                        }
+                    },
+                    "required": ["content", "status"]
+                }
             ),
             ToolParameter(
                 name="action",
                 type="string",
                 description="操作类型：create|update|clear（默认 create）",
                 required=False,
-                default="create"
+                default="create",
+                enum=["create", "update", "clear"]
             )
         ]
 
@@ -384,4 +408,3 @@ class TodoWriteTool(Tool):
             summary=data.get("summary", ""),
             todos=todos
         )
-

--- a/tests/test_llm_function_calling.py
+++ b/tests/test_llm_function_calling.py
@@ -5,24 +5,23 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import pytest
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 from hello_agents.core.llm import HelloAgentsLLM
-from openai.types.chat import ChatCompletion
 
 
 class TestLLMFunctionCalling:
     """测试 LLM 的 Function Calling 接口"""
     
     @pytest.fixture
-    def mock_openai_client(self):
-        """创建 Mock OpenAI 客户端"""
-        with patch('hello_agents.core.llm.OpenAI') as mock_openai:
-            mock_client = MagicMock()
-            mock_openai.return_value = mock_client
-            yield mock_client
+    def mock_adapter(self):
+        """创建 Mock LLM 适配器"""
+        with patch('hello_agents.core.llm.create_adapter') as mock_create_adapter:
+            mock_adapter = MagicMock()
+            mock_create_adapter.return_value = mock_adapter
+            yield mock_adapter
     
     @pytest.fixture
-    def llm(self, mock_openai_client):
+    def llm(self, mock_adapter):
         """创建 HelloAgentsLLM 实例"""
         with patch.dict('os.environ', {
             'LLM_API_KEY': 'test-key',
@@ -31,7 +30,7 @@ class TestLLMFunctionCalling:
         }):
             return HelloAgentsLLM()
     
-    def test_invoke_with_tools_basic(self, llm, mock_openai_client):
+    def test_invoke_with_tools_basic(self, llm, mock_adapter):
         """测试基本的 Function Calling 调用"""
         # 准备测试数据
         messages = [{"role": "user", "content": "计算 2+3"}]
@@ -51,29 +50,31 @@ class TestLLMFunctionCalling:
         }]
         
         # Mock 响应
-        mock_response = MagicMock(spec=ChatCompletion)
-        mock_openai_client.chat.completions.create.return_value = mock_response
+        mock_response = MagicMock()
+        mock_adapter.invoke_with_tools.return_value = mock_response
         
         # 调用方法
         response = llm.invoke_with_tools(messages, tools, tool_choice="auto")
         
         # 验证调用
-        mock_openai_client.chat.completions.create.assert_called_once()
-        call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
-        
-        assert call_kwargs["model"] == "test-model"
-        assert call_kwargs["messages"] == messages
-        assert call_kwargs["tools"] == tools
+        mock_adapter.invoke_with_tools.assert_called_once()
+        call_args = mock_adapter.invoke_with_tools.call_args
+        call_kwargs = call_args.kwargs
+
+        assert llm.model == "test-model"
+        assert call_args.args[0] == messages
+        assert call_args.args[1] == tools
         assert call_kwargs["tool_choice"] == "auto"
+        assert call_kwargs["temperature"] == 0.7
         assert response == mock_response
     
-    def test_invoke_with_tools_custom_params(self, llm, mock_openai_client):
+    def test_invoke_with_tools_custom_params(self, llm, mock_adapter):
         """测试自定义参数传递"""
         messages = [{"role": "user", "content": "测试"}]
         tools = []
         
-        mock_response = MagicMock(spec=ChatCompletion)
-        mock_openai_client.chat.completions.create.return_value = mock_response
+        mock_response = MagicMock()
+        mock_adapter.invoke_with_tools.return_value = mock_response
         
         # 使用自定义参数
         response = llm.invoke_with_tools(
@@ -84,12 +85,12 @@ class TestLLMFunctionCalling:
             max_tokens=1000
         )
         
-        call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+        call_kwargs = mock_adapter.invoke_with_tools.call_args.kwargs
         assert call_kwargs["temperature"] == 0.5
         assert call_kwargs["max_tokens"] == 1000
         assert call_kwargs["tool_choice"] == "required"
     
-    def test_invoke_with_tools_error_handling(self, llm, mock_openai_client):
+    def test_invoke_with_tools_error_handling(self, llm, mock_adapter):
         """测试错误处理"""
         from hello_agents.core.exceptions import HelloAgentsException
         
@@ -97,7 +98,9 @@ class TestLLMFunctionCalling:
         tools = []
         
         # Mock 抛出异常
-        mock_openai_client.chat.completions.create.side_effect = Exception("API 错误")
+        mock_adapter.invoke_with_tools.side_effect = HelloAgentsException(
+            "Function Calling 调用失败: API 错误"
+        )
         
         # 应该抛出 HelloAgentsException
         with pytest.raises(HelloAgentsException) as exc_info:
@@ -146,4 +149,3 @@ class TestLLMFunctionCallingIntegration:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-

--- a/tests/test_tool_schema.py
+++ b/tests/test_tool_schema.py
@@ -1,0 +1,95 @@
+"""工具 JSON Schema 生成测试"""
+
+from hello_agents.agents.react_agent import ReActAgent
+from hello_agents.core.config import Config
+from hello_agents.tools.builtin.devlog_tool import DevLogTool
+from hello_agents.tools.builtin.file_tools import MultiEditTool
+from hello_agents.tools.builtin.todowrite_tool import TodoWriteTool
+from hello_agents.tools.registry import ToolRegistry
+
+
+class DummyLLM:
+    """用于 schema 测试的轻量 LLM 桩对象"""
+
+    def __init__(self, model: str = "gpt-3.5-turbo"):
+        self.model = model
+
+
+class TestToolSchemaGeneration:
+    """测试工具 schema 构建"""
+
+    def test_todowrite_to_openai_schema_includes_array_items(self, tmp_path):
+        """TodoWrite 的数组参数应包含 items 定义"""
+        tool = TodoWriteTool(project_root=str(tmp_path), persistence_dir="todos")
+
+        schema = tool.to_openai_schema()
+        todo_param = schema["function"]["parameters"]["properties"]["todos"]
+        action_param = schema["function"]["parameters"]["properties"]["action"]
+
+        assert todo_param["type"] == "array"
+        assert todo_param["items"]["type"] == "object"
+        assert todo_param["items"]["properties"]["status"]["enum"] == [
+            "pending",
+            "in_progress",
+            "completed"
+        ]
+        assert action_param["enum"] == ["create", "update", "clear"]
+
+    def test_multiedit_to_openai_schema_preserves_object_array_shape(self, tmp_path):
+        """MultiEdit 的 edits 参数应保留对象数组结构"""
+        tool = MultiEditTool(project_root=str(tmp_path), working_dir=str(tmp_path))
+
+        schema = tool.to_openai_schema()
+        edits_param = schema["function"]["parameters"]["properties"]["edits"]
+
+        assert edits_param["type"] == "array"
+        assert edits_param["items"]["type"] == "object"
+        assert edits_param["items"]["required"] == ["old_string", "new_string"]
+        assert edits_param["items"]["properties"]["old_string"]["type"] == "string"
+        assert edits_param["items"]["properties"]["new_string"]["type"] == "string"
+
+    def test_devlog_to_openai_schema_includes_enum(self, tmp_path):
+        """DevLog 的枚举参数应保留在 schema 中"""
+        tool = DevLogTool(
+            session_id="s-test",
+            agent_name="schema-test",
+            project_root=str(tmp_path),
+            persistence_dir="devlogs"
+        )
+
+        schema = tool.to_openai_schema()
+        action_param = schema["function"]["parameters"]["properties"]["action"]
+        category_param = schema["function"]["parameters"]["properties"]["category"]
+
+        assert action_param["enum"] == ["append", "read", "summary", "clear"]
+        assert "decision" in category_param["enum"]
+
+    def test_react_agent_builds_todowrite_schema_with_items(self, tmp_path):
+        """ReActAgent 组装工具 schema 时不应丢失数组 items"""
+        registry = ToolRegistry()
+        registry.register_tool(
+            TodoWriteTool(project_root=str(tmp_path), persistence_dir="todos")
+        )
+        agent = ReActAgent(
+            name="schema-agent",
+            llm=DummyLLM(),
+            tool_registry=registry,
+            config=Config(
+                trace_enabled=False,
+                skills_enabled=False,
+                session_enabled=False,
+                subagent_enabled=False,
+                devlog_enabled=False,
+                todowrite_enabled=False
+            )
+        )
+
+        schemas = agent._build_tool_schemas()
+        todo_schema = next(
+            schema for schema in schemas
+            if schema["function"]["name"] == "TodoWrite"
+        )
+        todo_param = todo_schema["function"]["parameters"]["properties"]["todos"]
+
+        assert todo_param["type"] == "array"
+        assert todo_param["items"]["type"] == "object"


### PR DESCRIPTION
### 背景

  运行 uv run examples/async_agent_demo.py 时，Agent 在第一次 LLM function calling 阶段失败，报
  错为：

  Invalid schema for function 'TodoWrite': array schema missing items

  ### 根因

  问题的本质不是 TodoWrite 的业务逻辑错误，而是工具 JSON Schema 的生成链路不一致。

  Agent 侧在组装 function calling schema 时使用了简化逻辑，只保留了参数的 type 和 description，
  导致数组参数缺少必需的 items，枚举参数的 enum 等结构信息也会丢失。最终像 TodoWrite.todos 这样
  的对象数组参数会生成不合法的 schema，并被 OpenAI 拒绝。

  ### 修复

  本 PR 将工具 schema 生成统一收口到 Tool.to_openai_schema() /
  ToolParameter.to_openai_schema()，避免 Agent 侧重复实现并丢失字段。

  具体改动包括：

  - 统一 Agent 与 Tool 的 OpenAI schema 生成路径
  - 为 ToolParameter 增加 enum、items、properties、additional_properties 支持
  - 为 TodoWrite.todos 补充对象数组的 items 定义
  - 为 MultiEdit.edits 补充对象数组的 items 定义
  - 保留 action、status 等枚举约束
  - 增加 schema 回归测试，覆盖工具级和 Agent 组装级场景

  ### 结果

  修复后，TodoWrite 不再生成非法的数组 schema；同时这次改动也一并修复了同类工具在 OpenAI
  function calling 下可能出现的相同问题，而不是只针对单个 demo 做特例处理。

  ### 验证

  已通过：

  pytest tests/test_tool_schema.py tests/test_llm_function_calling.py -q