### PR TITLE
fix: 修复异步调用工具退出异常问题

### DIFF
--- a/hello_agents/tools/builtin/protocol_tools.py
+++ b/hello_agents/tools/builtin/protocol_tools.py
@@ -11,6 +11,17 @@ from typing import Dict, Any, List, Optional
 from ..base import Tool, ToolParameter
 import os
 
+import gc
+import asyncio
+import sys
+if sys.platform == "win32":
+    # 使用 SelectorEventLoop 替代 ProactorEventLoop，
+    # 可避免 GetQueuedCompletionStatus 阻塞问题
+    if sys.version_info >= (3, 8):
+        asyncio.set_event_loop_policy(
+            asyncio.WindowsSelectorEventLoopPolicy()
+        )
+        
 
 # MCP服务器环境变量映射表
 # 用于自动检测常见MCP服务器需要的环境变量
@@ -354,6 +365,7 @@ class MCPTool(Tool):
             操作结果
         """
         from hello_agents.protocols.mcp.client import MCPClient
+        timeout = getattr(self, 'timeout', 10)
 
         # 智能推断action：如果没有action但有tool_name，自动设置为call_tool
         action = parameters.get("action", "").lower()
@@ -393,7 +405,7 @@ class MCPTool(Tool):
                         arguments = parameters.get("arguments", {})
                         if not tool_name:
                             return "错误：必须指定 tool_name 参数"
-                        result = await client.call_tool(tool_name, arguments)
+                        result = await asyncio.wait_for(client.call_tool(tool_name, arguments), timeout=timeout)
                         return f"工具 '{tool_name}' 执行结果:\n{result}"
 
                     elif action == "list_resources":
@@ -451,17 +463,31 @@ class MCPTool(Tool):
                         try:
                             return new_loop.run_until_complete(run_mcp_operation())
                         finally:
+                            # 取消所有残留任务，防止 transport 未关闭
+                            pending = asyncio.all_tasks(new_loop)
+                            for task in pending:
+                                task.cancel()
+                            if pending:
+                                new_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
                             new_loop.close()
 
-                    with concurrent.futures.ThreadPoolExecutor() as executor:
+                    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                    try:
                         future = executor.submit(run_in_thread)
-                        return future.result()
+                        # 设置超时，避免永久阻塞
+                        return future.result(timeout=timeout)
+                    finally:
+                        # 不等待残留线程，直接关闭线程池
+                        executor.shutdown(wait=False, cancel_futures=True)
                 except RuntimeError:
                     # 没有运行中的循环，直接运行
                     return asyncio.run(run_mcp_operation())
             except Exception as e:
                 return f"异步操作失败: {str(e)}"
-                    
+            finally:
+                # 强制回收未关闭的管道/文件描述符
+                gc.collect()
+
         except Exception as e:
             return f"MCP 操作失败: {str(e)}"
     


### PR DESCRIPTION
问题现象：通过MCPTool调用@mzxrai/mcp-webresearch工具，会出现进程卡死问题。经过分析，原因是该包基于 Playwright，目前的代码导致异步任务已执行完毕，但底层资源（子进程/管道/事件循环/线程池）未被正确释放。

解决方法：通过增加超时设置以及资源回收等方法

验证代码（第一个result可以打印，第二个result无法打印，修复后可以打印）：

from hello_agents.tools import MCPTool

web_search_tool = MCPTool(name="web research", server_command=["npx", "-y", "@mzxrai/mcp-webresearch@latest"])

result = web_search_tool.run({"action": "list_tools"})
print(result)

result = web_search_tool.run({
    "action": "call_tool",
    "tool_name": "visit_page",
    "arguments": {
        "url": "https://www.xiangha.com/so/?q=caipu&s=五花肉"
    }
})
print(result)