### PR TITLE
fix(calculator): remove ast.Num branch dropped in Python 3.14

### DIFF
--- a/hello_agents/tools/builtin/calculator.py
+++ b/hello_agents/tools/builtin/calculator.py
@@ -105,8 +105,6 @@ class CalculatorTool(Tool):
         """递归计算AST节点"""
         if isinstance(node, ast.Constant):  # Python 3.8+
             return node.value
-        elif isinstance(node, ast.Num):  # Python < 3.8
-            return node.n
         elif isinstance(node, ast.BinOp):
             return self.OPERATORS[type(node.op)](
                 self._eval_node(node.left), 


### PR DESCRIPTION
## Problem

`ast.Num` was deprecated in Python 3.8 and **fully removed in Python 3.14**. On Python 3.14+, the `elif isinstance(node, ast.Num)` branch raises `AttributeError: module ast has no attribute Num`, crashing any calculation.

## Fix

Remove the two-line dead-code branch. `ast.Constant` already handles all numeric literals since Python 3.8 (the branch above it), so there is no behavioural change on any supported Python version.

```diff
-        elif isinstance(node, ast.Num):  # Python < 3.8
-            return node.n
```

## Verification

Tested expressions `2+3*4`, `100/4`, `2**10` all evaluate correctly after the removal.

Ref: https://github.com/datawhalechina/hello-agents/issues/510