### PR TITLE
fix: prefer model_dump in Config.to_dict for pydantic v2

### DIFF
--- a/hello_agents/core/config.py
+++ b/hello_agents/core/config.py
@@ -100,4 +100,6 @@ class Config(BaseModel):
 
     def to_dict(self) -> Dict[str, Any]:
         """转换为字典"""
+        if hasattr(self, "model_dump"):
+            return self.model_dump()
         return self.dict()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+"""Config model helper tests."""
+
+import warnings
+
+from hello_agents.core.config import Config
+
+
+def test_to_dict_uses_model_dump_no_deprecated_warning() -> None:
+    """Config.to_dict should use Pydantic v2 serializer without deprecated dict()."""
+
+    config = Config()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        data = config.to_dict()
+
+    if hasattr(config, "model_dump"):
+        assert data == config.model_dump()
+    else:
+        assert data == config.dict()
+
+    assert all(
+        "use `model_dump`" not in str(w.message)
+        for w in caught
+    )


### PR DESCRIPTION
## Summary
Closes compatibility issue with Pydantic v2 serialization by updating `Config.to_dict()` to use `model_dump()` when available, while keeping `dict()` as a safe fallback for older Pydantic versions.

## Changes
- Updated `Config.to_dict()` in `hello_agents/core/config.py`:
  - Uses `self.model_dump()` on Pydantic v2.
  - Falls back to `self.dict()` for backward compatibility.
- Added regression test `tests/test_config.py` to validate:
  - `to_dict()` output matches the active Pydantic serializer (`model_dump` when present).
  - No `model_dump` deprecation warning text is emitted from the call.

## Issue
- Fixes #79 (`to_dict()` 已淘汰了，应换成model_dump())

## Verification
- `python3 -m pytest tests/test_config.py -q`
- `ruff check hello_agents/core/config.py tests/test_config.py`
- `python3 -m py_compile hello_agents/core/config.py tests/test_config.py`

## Risk / Notes
- Fallback keeps compatibility with environments pinned to older Pydantic versions.
- Static baseline checks (`mypy` across full repo) fail due pre-existing unrelated type issues.
