### PR TITLE
qwen有些模型如果是非流式输出必须要关闭深度思考，但是设置 enable_thinking=False并没生效。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 .obsidian
 .pytest_cache
 .venv
+/memory/traces/*

--- a/hello_agents/core/llm.py
+++ b/hello_agents/core/llm.py
@@ -135,12 +135,14 @@ class HelloAgentsLLM:
             if response.reasoning_content:  # thinking model的推理过程
                 print(response.reasoning_content)
         """
-        # 合并参数
-        call_kwargs = {
-            "temperature": kwargs.pop("temperature", self.temperature),
-        }
-        if self.max_tokens:
-            call_kwargs["max_tokens"] = kwargs.pop("max_tokens", self.max_tokens)
+        # 合并参数：调用参数 > 初始化参数（self.kwargs） > 默认参数
+        temperature = kwargs.pop("temperature", self.temperature)
+        max_tokens = kwargs.pop("max_tokens", self.max_tokens)
+
+        call_kwargs = dict(self.kwargs)
+        call_kwargs["temperature"] = temperature
+        if max_tokens is not None:
+            call_kwargs["max_tokens"] = max_tokens
         call_kwargs.update(kwargs)
 
         return self._adapter.invoke(messages, **call_kwargs)
@@ -160,12 +162,12 @@ class HelloAgentsLLM:
         Note:
             流式调用结束后，可通过 llm.last_call_stats 获取统计信息
         """
-        temperature = kwargs.pop("temperature", None)
+        max_tokens = kwargs.pop("max_tokens", self.max_tokens)
 
-        # 准备参数
-        call_kwargs = {}
-        if self.max_tokens:
-            call_kwargs["max_tokens"] = kwargs.pop("max_tokens", self.max_tokens)
+        call_kwargs = dict(self.kwargs)
+        if max_tokens is not None:
+            call_kwargs["max_tokens"] = max_tokens
+
         call_kwargs.update(kwargs)
 
         for chunk in self._adapter.stream_invoke(messages, temperature=temperature, **call_kwargs):
@@ -203,13 +205,14 @@ class HelloAgentsLLM:
         Raises:
             HelloAgentsException: 当 LLM 调用失败时
         """
-        # 合并参数
-        call_kwargs = {
-            "temperature": kwargs.pop("temperature", self.temperature),
-            "tool_choice": tool_choice,
-        }
-        if self.max_tokens:
-            call_kwargs["max_tokens"] = kwargs.pop("max_tokens", self.max_tokens)
+        temperature = kwargs.pop("temperature", self.temperature)
+        max_tokens = kwargs.pop("max_tokens", self.max_tokens)
+
+        call_kwargs = dict(self.kwargs)
+        call_kwargs["temperature"] = temperature
+        call_kwargs["tool_choice"] = tool_choice
+        if max_tokens is not None:
+            call_kwargs["max_tokens"] = max_tokens
         call_kwargs.update(kwargs)
 
         return self._adapter.invoke_with_tools(messages, tools, **call_kwargs)

--- a/hello_agents/core/llm_adapters.py
+++ b/hello_agents/core/llm_adapters.py
@@ -109,6 +109,28 @@ class OpenAIAdapter(BaseLLMAdapter):
             base_url=self.base_url,
             timeout=self.timeout
         )
+
+    def _normalize_thinking_kwargs(self, kwargs: Dict[str, Any], *, non_streaming: bool) -> Dict[str, Any]:
+        normalized = dict(kwargs)
+        
+        enable_thinking = normalized.pop("enable_thinking", None)
+        extra_body = normalized.get("extra_body")
+        
+        if extra_body is None:
+            extra_body = {}
+        
+        if isinstance(extra_body, dict):
+            merged_extra_body = dict(extra_body)
+            
+            if enable_thinking is not None:
+                merged_extra_body["enable_thinking"] = bool(enable_thinking)
+            
+            if non_streaming and "enable_thinking" not in merged_extra_body:
+                merged_extra_body["enable_thinking"] = False
+            
+            normalized["extra_body"] = merged_extra_body
+        
+        return normalized
     
     def invoke(self, messages: List[Dict], **kwargs) -> LLMResponse:
         """非流式调用"""
@@ -118,6 +140,7 @@ class OpenAIAdapter(BaseLLMAdapter):
         start_time = time.time()
         
         try:
+            kwargs = self._normalize_thinking_kwargs(kwargs, non_streaming=True)
             response = self._client.chat.completions.create(
                 model=self.model,
                 messages=messages,
@@ -168,6 +191,7 @@ class OpenAIAdapter(BaseLLMAdapter):
         start_time = time.time()
         
         try:
+            kwargs = self._normalize_thinking_kwargs(kwargs, non_streaming=True)
             response = self._client.chat.completions.create(
                 model=self.model,
                 messages=messages,


### PR DESCRIPTION
执行hello-agents教程中例子到 llm = HelloAgentsLLM()这一行时报错
报错：Traceback (most recent call last):
  File "d:\project\HelloAgents\hello_agents\core\llm_adapters.py", line 121, in invoke
    response = self._client.chat.completions.create(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\software\anaconda\Lib\site-packages\openai\_utils\_utils.py", line 286, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "D:\software\anaconda\Lib\site-packages\openai\resources\chat\completions\completions.py", line 1147, in create
    return self._post(
           ^^^^^^^^^^^
or'}, 'id': 'chatcmpl-ebd7a975-de9b-9d01-969c-7102e144a219', 'request_id': 'ebd7a975-de9b-9d01-969c-7102e144a219'}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "d:\project\HelloAgents\test.py", line 22, in <module>
    response = agent.run("你好！请介绍一下自己")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "d:\project\HelloAgents\hello_agents\agents\simple_agent.py", line 102, in run
    llm_response = self.llm.invoke(messages, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "d:\project\HelloAgents\hello_agents\core\llm.py", line 146, in invoke
    return self._adapter.invoke(messages, **call_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "d:\project\HelloAgents\hello_agents\core\llm_adapters.py", line 161, in invoke
    raise HelloAgentsException(f"OpenAI API调用失败: {str(e)}")
hello_agents.core.exceptions.HelloAgentsException: OpenAI API调用失败: Error code: 400 - {'error': {'message': 'parameter.enable_thinking must be set to false for non-streaming calls', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_parameter_error'}, 'id': 'chatcmpl-ebd7a975-de9b-9d01-969c-7102e144a219', 'request_id': 'ebd7a975-de9b-9d01-969c-7102e144a219'}
因为使用的qwen模型再非流式时必须关闭深度思考，但是llm = HelloAgentsLLM(enable_thinking=False)仍然报错：
Traceback (most recent call last):
  File "d:\project\HelloAgents\hello_agents\core\llm_adapters.py", line 121, in invoke
    response = self._client.chat.completions.create(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\software\anaconda\Lib\site-packages\openai\_utils\_utils.py", line 286, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
TypeError: Completions.create() got an unexpected keyword argument 'enable_thinking'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "d:\project\HelloAgents\test.py", line 22, in <module>
    response = agent.run("你好！请介绍一下自己")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "d:\project\HelloAgents\hello_agents\agents\simple_agent.py", line 102, in run
    llm_response = self.llm.invoke(messages, **kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "d:\project\HelloAgents\hello_agents\core\llm.py", line 148, in invoke
    return self._adapter.invoke(messages, **call_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "d:\project\HelloAgents\hello_agents\core\llm_adapters.py", line 161, in invoke
    raise HelloAgentsException(f"OpenAI API调用失败: {str(e)}")
hello_agents.core.exceptions.HelloAgentsException: OpenAI API调用失败: Completions.create() got an unexpected keyword argument 'enable_thinking'

原因：
HelloAgentsLLM.__init__(..., **kwargs) 里虽然接收了 enable_thinking=False ，但 原实现没有把这些 kwargs 带到每次请求里 ，所以请求照样按服务端默认（可能是 thinking=true）发出 
同时修改：
OpenAI 适配器里把 enable_thinking 自动映射到 extra_body ，并在非流式时默认强制为 false

修复：
1. 修复 LLM 初始化 kwargs 没有参与调用的问题：
<img width="2500" height="1656" alt="image" src="https://github.com/user-attachments/assets/97894eef-1f4f-40a4-9394-7407ebcb5edf" />
2. OpenAI 适配器里把 enable_thinking 自动映射到 extra_body ，并在非流式时默认强制为 false
    def _normalize_thinking_kwargs(self, kwargs: Dict[str, Any], *, non_streaming: bool) -> Dict[str, Any]:
        normalized = dict(kwargs)
        
        enable_thinking = normalized.pop("enable_thinking", None)
        extra_body = normalized.get("extra_body")
        
        if extra_body is None:
            extra_body = {}
        
        if isinstance(extra_body, dict):
            merged_extra_body = dict(extra_body)
            
            if enable_thinking is not None:
                merged_extra_body["enable_thinking"] = bool(enable_thinking)
            
            if non_streaming and "enable_thinking" not in merged_extra_body:
                merged_extra_body["enable_thinking"] = False
            
            normalized["extra_body"] = merged_extra_body
        
        return normalized