### PR TITLE
fix(context): 修复 ContextBuilder._gather() 中 memory_tool 的调用接口不匹配问题。

### DIFF
--- a/hello_agents/context/builder.py
+++ b/hello_agents/context/builder.py
@@ -140,12 +140,12 @@ class ContextBuilder:
         if self.memory_tool:
             try:
                 # 搜索任务状态相关记忆
-                state_results = self.memory_tool.execute(
-                    "search",
-                    query="(任务状态 OR 子目标 OR 结论 OR 阻塞)",
-                    min_importance=0.7,
-                    limit=5
-                )
+                state_results = self.memory_tool.run({
+                    "action": "search",
+                    "query": "(任务状态 OR 子目标 OR 结论 OR 阻塞)",
+                    "min_importance": 0.7,
+                    "limit": 5
+                })
                 if state_results and "未找到" not in state_results:
                     packets.append(ContextPacket(
                         content=state_results,
@@ -153,11 +153,11 @@ class ContextBuilder:
                     ))
                 
                 # 搜索与当前查询相关的记忆
-                related_results = self.memory_tool.execute(
-                    "search",
-                    query=user_query,
-                    limit=5
-                )
+                related_results = self.memory_tool.run({
+                    "action": "search",
+                    "query": user_query,
+                    "limit": 5
+                })
                 if related_results and "未找到" not in related_results:
                     packets.append(ContextPacket(
                         content=related_results,


### PR DESCRIPTION
# 关联Issue
Fixes #90 
# 问题背景
在 `ContextBuilder._gather()` 方法中，memory tool 的调用方式使用的 `execute(action, **kwargs)` 接口在 memory tool 中并不存在：

```python
state_results = self.memory_tool.execute(
    "search",
    query="(任务状态 OR 子目标 OR 结论 OR 阻塞)",
    min_importance=0.7,
    limit=5
)
```
# 解决方案
将 `_gather()` 方法中的两处 `memory_tool.execute()` 修改为 `memory_tool.run()` 接口：

```python
# 变更前
state_results = self.memory_tool.execute(
    "search",
    query="(任务状态 OR 子目标 OR 结论 OR 阻塞)",
    min_importance=0.7,
    limit=5
)

# 变更后
state_results = self.memory_tool.run({
    "action": "search",
    "query": "(任务状态 OR 子目标 OR 结论 OR 阻塞)",
    "min_importance": 0.7,
    "limit": 5
})
```

两处调用均位于 `_gather()` 方法内：

- **L143-148**：任务状态记忆检索
- **L156-160**：用户查询关联记忆检索