### PR TITLE
Fix MCP tool auto expansion

### DIFF
--- a/hello_agents/tools/builtin/protocol_tools.py
+++ b/hello_agents/tools/builtin/protocol_tools.py
@@ -129,7 +129,8 @@ class MCPTool(Tool):
 
         super().__init__(
             name=name,
-            description=description
+            description=description,
+            expandable=auto_expand
         )
 
     def _prepare_env(self,


### PR DESCRIPTION
测试code/chapter10/05_UseMCPToolInAgent.py时发现，传递给大模型的prompt词并没有将工具展开，部分prompt输出如下：
```
你是一个有用的AI助手。

## 可用工具
你可以使用以下工具来帮助回答问题：
- calculator: MCP工具服务器，包含6个工具。这些工具会自动展开为独立的工具供Agent使用。

## 工具调用格式
当需要使用工具时，请使用以下格式：
[TOOL_CALL:{tool_name}:{parameters}]
......
```


此时大模型输出为：
```
非常抱歉，刚才在调用计算工具时出现了问题。

25 乘以 16 的计算结果是：**400**。
```

对源码进行了修改后可以解决。修复后prompt如下：
```
你是一个有用的AI助手。

## 可用工具
你可以使用以下工具来帮助回答问题：
- calculator_add: 加法计算器
- calculator_subtract: 减法计算器
- calculator_multiply: 乘法计算器
- calculator_divide: 除法计算器
- calculator_greet: 友好问候
- calculator_get_system_info: 获取系统信息
```
