### PR TITLE
修复 database_config 加载环境变量路径错误问题 (target: learn_version)

### DIFF
--- a/hello_agents/core/database_config.py
+++ b/hello_agents/core/database_config.py
@@ -4,7 +4,7 @@
 """
 
 import os
-from dotenv import load_dotenv
+from dotenv import load_dotenv,find_dotenv
 from typing import Dict, Any, Optional
 from pydantic import BaseModel, Field
 import logging
@@ -12,8 +12,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Load environment variables early so DB configs pick them up
-load_dotenv()
-
+env_path=find_dotenv(usecwd=True)
+load_dotenv(env_path)
 
 class QdrantConfig(BaseModel):
     """Qdrant向量数据库配置"""


### PR DESCRIPTION
## 问题
当前的修复版本依赖每次用户手动在文件最开始手动加载
``` python
from dotenv import load_dotenv
load_dotenv()
```
这种方式不太方便。实际上 `dotenv` 提供了修改默认 `env` 位置的方法  `find_dotenv( )`，该方法在 `load_dotenv` 注释中被官方提及
``` python
"""
    If both `dotenv_path` and `stream` are `None`, `find_dotenv()` is used to find the
    .env file with it's default parameters. If you need to change the default parameters
    of `find_dotenv()`, you can explicitly call `find_dotenv()` and pass the result
    to this function as `dotenv_path`.
"""

def find_dotenv(
    filename: str = ".env",
    raise_error_if_not_found: bool = False,
    usecwd: bool = False,
) -> str:
    """
    Search in increasingly higher folders for the given file

    Returns path to the file if found, or an empty string otherwise
    """
```
只需要设置`usecwd=True`即可实现自动加载工作目录同级的`.env`文件。该方案更加优雅且通用。

## 修复

使用 `dotenv` 官方推荐的 `find_dotenv(usecwd=True)` 从当前工作目录向上查找 `.env` 文件，替代无参 `load_dotenv()`。该方案：

- 无需用户手动进行环境变量加载
- 适配任意 CWD（只要在 .env 所在目录或其子目录运行）
- 是 dotenv 文档中明确推荐的用法

## 额外说明
该改动增强了现有的保底策略。如果想要用户完全不需手动加载。可以将`semantic.py`中的`get_database_config`导入提升到模块级。
```python
def _init_databases(self):
        """初始化专业数据库存储"""
        try:
            # 需要放到正常头文件加载位置，否则用户未手动加载环境，前面的流程仍然可能报错
            from ...core.database_config import get_database_config
            # 获取数据库配置
            db_config = get_database_config()
            ...
```

该方案我已经在本地多次测试，运行无误。希望意见能被采纳