### PR TITLE
feat(llm): add Atlas Cloud environment fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,11 @@ LLM_BASE_URL=your-api-base-url
 # 超时时间（可选，默认60秒）
 LLM_TIMEOUT=60
 
+# Atlas Cloud 快捷配置（可选，未设置通用 LLM_* 时生效）
+# ATLASCLOUD_API_KEY=your-atlas-cloud-api-key
+# ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
+# ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-pro
+
 # ============================================================================
 # 🛠️ 工具配置（可选）
 # ============================================================================

--- a/hello_agents/core/llm.py
+++ b/hello_agents/core/llm.py
@@ -8,6 +8,17 @@ from .exceptions import HelloAgentsException
 from .llm_response import LLMResponse, StreamStats, LLMToolResponse
 from .llm_adapters import create_adapter, BaseLLMAdapter
 
+_ATLAS_BASE_URL = "https://api.atlascloud.ai/v1"
+_ATLAS_MODEL = "deepseek-ai/deepseek-v4-pro"
+
+
+def _first_env(*names: str) -> Optional[str]:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return None
+
 
 class HelloAgentsLLM:
     """
@@ -49,9 +60,31 @@ class HelloAgentsLLM:
             timeout: 超时时间（秒），默认从 LLM_TIMEOUT 读取，默认60秒
         """
         # 加载配置
+        generic_api_key = os.getenv("LLM_API_KEY")
+        atlas_api_key = _first_env("ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY")
+        uses_atlas_fallback = (
+            not api_key and not generic_api_key and bool(atlas_api_key)
+        )
+
         self.model = model or os.getenv("LLM_MODEL_ID")
-        self.api_key = api_key or os.getenv("LLM_API_KEY")
+        self.api_key = api_key or generic_api_key or atlas_api_key
         self.base_url = base_url or os.getenv("LLM_BASE_URL")
+        if uses_atlas_fallback:
+            self.model = (
+                self.model
+                or _first_env("ATLASCLOUD_MODEL", "ATLAS_CLOUD_MODEL")
+                or _ATLAS_MODEL
+            )
+            self.base_url = (
+                self.base_url
+                or _first_env(
+                    "ATLASCLOUD_BASE_URL",
+                    "ATLAS_CLOUD_BASE_URL",
+                    "ATLASCLOUD_API_BASE",
+                    "ATLAS_CLOUD_API_BASE",
+                )
+                or _ATLAS_BASE_URL
+            )
         self.timeout = timeout or int(os.getenv("LLM_TIMEOUT", "60"))
 
         self.temperature = temperature

--- a/tests/test_llm_atlascloud_config.py
+++ b/tests/test_llm_atlascloud_config.py
@@ -1,0 +1,65 @@
+"""Atlas Cloud environment fallback tests."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from hello_agents.core.llm import HelloAgentsLLM
+
+
+@patch("hello_agents.core.llm.create_adapter")
+def test_atlascloud_key_uses_openai_compatible_defaults(create_adapter: MagicMock):
+    with patch.dict(
+        os.environ,
+        {"ATLASCLOUD_API_KEY": "atlas-key"},
+        clear=True,
+    ):
+        llm = HelloAgentsLLM()
+
+    assert llm.api_key == "atlas-key"
+    assert llm.base_url == "https://api.atlascloud.ai/v1"
+    assert llm.model == "deepseek-ai/deepseek-v4-pro"
+    create_adapter.assert_called_once_with(
+        api_key="atlas-key",
+        base_url="https://api.atlascloud.ai/v1",
+        timeout=60,
+        model="deepseek-ai/deepseek-v4-pro",
+    )
+
+
+@patch("hello_agents.core.llm.create_adapter")
+def test_atlas_cloud_aliases_override_atlas_defaults(create_adapter: MagicMock):
+    with patch.dict(
+        os.environ,
+        {
+            "ATLAS_CLOUD_API_KEY": "atlas-key",
+            "ATLAS_CLOUD_BASE_URL": "https://atlas.example/v1",
+            "ATLAS_CLOUD_MODEL": "qwen/qwen3.5-flash",
+        },
+        clear=True,
+    ):
+        llm = HelloAgentsLLM()
+
+    assert llm.api_key == "atlas-key"
+    assert llm.base_url == "https://atlas.example/v1"
+    assert llm.model == "qwen/qwen3.5-flash"
+
+
+@patch("hello_agents.core.llm.create_adapter")
+def test_generic_llm_environment_keeps_priority(create_adapter: MagicMock):
+    with patch.dict(
+        os.environ,
+        {
+            "LLM_API_KEY": "generic-key",
+            "LLM_BASE_URL": "https://generic.example/v1",
+            "LLM_MODEL_ID": "generic-model",
+            "ATLASCLOUD_API_KEY": "atlas-key",
+            "ATLASCLOUD_BASE_URL": "https://api.atlascloud.ai/v1",
+            "ATLASCLOUD_MODEL": "deepseek-ai/deepseek-v4-pro",
+        },
+        clear=True,
+    ):
+        llm = HelloAgentsLLM()
+
+    assert llm.api_key == "generic-key"
+    assert llm.base_url == "https://generic.example/v1"
+    assert llm.model == "generic-model"


### PR DESCRIPTION
## Summary

- support `ATLASCLOUD_*` and `ATLAS_CLOUD_*` environment variables when the generic `LLM_*` configuration is absent
- default the Atlas shortcut to `https://api.atlascloud.ai/v1` and `deepseek-ai/deepseek-v4-pro`
- preserve the existing priority order: explicit constructor arguments, then generic `LLM_*`, then Atlas-specific fallback
- add focused tests for defaults, aliases, and generic configuration precedence

## Configuration

```env
ATLASCLOUD_API_KEY=your-atlas-cloud-api-key
ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-pro
```

The existing `LLM_API_KEY`, `LLM_BASE_URL`, and `LLM_MODEL_ID` configuration remains unchanged and takes priority.

## Validation

- focused LLM tests: 10 passed, 3 skipped
- Python compileall and `git diff --check` passed
- live `HelloAgentsLLM` chat completion through Atlas Cloud: exact `atlas-ok` response, 46 total tokens
- live Function Calling through Atlas Cloud: one `calculate` tool call with `{ "expression": "2+3" }`, 309 total tokens
- broader suite excluding the pre-existing collection blocker: 165 passed, 34 failed, 3 skipped, 4 errors; failures are existing environment/test issues such as missing `pytest-asyncio`, tests constructing an LLM without credentials, and unrelated tool assertions
- full collection is also blocked on the existing `PlanAndSolveAgent` import mismatch (`PlanSolveAgent` is exported)

No README, logo, sponsor, credits, or partner changes.