### PR TITLE
修复嵌入批量超 DashScope 上限与重试归一化导致分块静默丢失

### DIFF
--- a/hello_agents/memory/rag/pipeline.py
+++ b/hello_agents/memory/rag/pipeline.py
@@ -481,7 +481,7 @@ def index_chunks(
     store = None, 
     chunks: List[Dict] = None, 
     cache_db: Optional[str] = None, 
-    batch_size: int = 64,
+    batch_size: int = 10,
     rag_namespace: str = "default"
 ) -> None:
     """
@@ -575,7 +575,13 @@ def index_chunks(
                     
                     small_vecs = embedder.encode(small_part)
                     # Normalize to List[List[float]]
-                    if isinstance(small_vecs, list) and small_vecs and not isinstance(small_vecs[0], list):
+                    if not isinstance(small_vecs, list):
+                        if hasattr(small_vecs, "tolist"):
+                            small_vecs = small_vecs.tolist()
+                        else:
+                            small_vecs = [small_vecs]
+                    elif small_vecs and isinstance(small_vecs[0], (int, float)):
+                        # 单个向量（扁平浮点列表），包装为单元素列表
                         small_vecs = [small_vecs]
                     
                     for v in small_vecs:


### PR DESCRIPTION
Fixes #105

## 问题背景

在运行教程第八章 `11_Q&A_Assistant.py` 上传较大 PDF 时发现：94 个分块最终只有 12 个写入 Qdrant，且全部为零向量，导致 RAG 问答完全失效。问题无报错、日志显示成功，属于静默数据丢失。

## 修改内容

仅修改 `hello_agents/memory/rag/pipeline.py`，两处：

### 1. `index_chunks` 默认 `batch_size`：64 → 10

DashScope `text-embedding-v3` 单请求最多 10 条文本，默认 64 会导致每批必 400，强制走入有 bug 的重试路径。

### 2. 修复重试路径的向量归一化逻辑

原逻辑通过 `not isinstance(small_vecs[0], list)` 判断"是否为单个扁平向量"，但 DashScope / sentence-transformers 返回的是 `List[np.ndarray]`，首元素是 `np.ndarray` 而非 `list`，被误判后多包一层，导致每组 8 条只产出 1 个零向量。

修改为：仅当首元素是 `int/float`（真扁平向量）时才包装；非 list 类型（如 ndarray 矩阵）先 `tolist()` 再处理。

## 验证过程

测试文档：约 205,380 字符 PDF（分块 94 个）

| | 修复前 | 修复后 |
|---|---|---|
| Embedding | 两批全部 400，重试产出 12 个零向量 | 10 条/批，94/94 全部成功 |
| 入库日志 | `n_vectors=12 n_meta=94` | `n_vectors=94 n_meta=94` |
| Qdrant 点数 | 12（零向量，无法检索） | 94（真实向量） |
| 耗时 | >300s（含失败重试与 sleep） | ~30s |

## 未在本 PR 处理

`qdrant_store.add_vectors` 中 `zip(vectors, metadata, ids)` 数量不一致时静默截断的问题，建议后续单独加数量校验（已在 issue 中说明）。

## 目标分支说明

本 PR 基于并请求合并到 `learn_version` 分支（与教程及 pip 0.2.0 对应；`main` 分支已无此文件）。