### PR TITLE
docs: add Novita to supported LLM providers table

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ print(f"检测到的provider: {llm.provider}")
 
 | 提供商类型   | 示例服务                               | 配置示例                             |
 | ------------ | -------------------------------------- | ------------------------------------ |
-| **云端 API** | OpenAI、DeepSeek、Qwen、Kimi、智谱 GLM | `LLM_BASE_URL=api.deepseek.com`      |
+| **云端 API** | OpenAI、DeepSeek、Qwen、Kimi、智谱 GLM、Novita | `LLM_BASE_URL=api.deepseek.com`      |
 | **本地推理** | vLLM、Ollama、SGLang                   | `LLM_BASE_URL=http://localhost:8000` |
 | **其他兼容** | 任何 OpenAI 格式接口                   | `LLM_BASE_URL=your-endpoint`         |
 


### PR DESCRIPTION

## Summary

Novita exposes an OpenAI-compatible endpoint, so it works with the default OpenAI adapter the same way as the other cloud providers already listed in the README.

## Changes

- `README.md`: append Novita to the "云端 API" (cloud API) row of the supported LLM providers table, alongside OpenAI, DeepSeek, Qwen, Kimi, and 智谱 GLM.

## Verification

- `git diff HEAD^ HEAD -- README.md`: 1 file, +1/-1, documentation only.
- `PYTHONPATH=. pytest -q`: baseline and this change both show `163 passed, 6 skipped, 30 failed, 4 errors` when excluding the pre-existing `tests/test_all_agents.py` collection error; no new failures introduced.
- Live smoke test: `HelloAgentsLLM.invoke` via the Novita OpenAI-compatible endpoint succeeded (model `deepseek/deepseek-v4-pro`), returning non-empty content with `prompt_tokens`/`completion_tokens`/`total_tokens` usage.
