### PR TITLE
feat: add litellm provider

### DIFF
--- a/hello_agents/core/llm.py
+++ b/hello_agents/core/llm.py
@@ -30,6 +30,7 @@ class HelloAgentsLLM:
         model: Optional[str] = None,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
+        provider: Optional[str] = None,
         temperature: float = 0.7,
         max_tokens: Optional[int] = None,
         timeout: Optional[int] = None,
@@ -44,6 +45,8 @@ class HelloAgentsLLM:
             model: 模型名称，默认从 LLM_MODEL_ID 读取
             api_key: API密钥，默认从 LLM_API_KEY 读取
             base_url: 服务地址，默认从 LLM_BASE_URL 读取
+            provider: explicit adapter selection (openai/anthropic/gemini/litellm),
+                defaults to LLM_PROVIDER env; when empty, auto-detected from base_url
             temperature: 温度参数，默认0.7
             max_tokens: 最大token数
             timeout: 超时时间（秒），默认从 LLM_TIMEOUT 读取，默认60秒
@@ -52,26 +55,32 @@ class HelloAgentsLLM:
         self.model = model or os.getenv("LLM_MODEL_ID")
         self.api_key = api_key or os.getenv("LLM_API_KEY")
         self.base_url = base_url or os.getenv("LLM_BASE_URL")
+        self.provider = provider or os.getenv("LLM_PROVIDER")
         self.timeout = timeout or int(os.getenv("LLM_TIMEOUT", "60"))
 
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.kwargs = kwargs
 
+        # LiteLLM routes by model prefix + provider env vars, so api_key/base_url
+        # are optional on that path (e.g. anthropic/claude-... with ANTHROPIC_API_KEY).
+        is_litellm = (self.provider or "").lower() == "litellm"
+
         # 验证必要参数
         if not self.model:
             raise HelloAgentsException("必须提供模型名称（model参数或LLM_MODEL_ID环境变量）")
-        if not self.api_key:
+        if not self.api_key and not is_litellm:
             raise HelloAgentsException("必须提供API密钥（api_key参数或LLM_API_KEY环境变量）")
-        if not self.base_url:
+        if not self.base_url and not is_litellm:
             raise HelloAgentsException("必须提供服务地址（base_url参数或LLM_BASE_URL环境变量）")
 
-        # 创建适配器（自动检测）
+        # Create adapter (explicit provider wins, else auto-detect from base_url)
         self._adapter: BaseLLMAdapter = create_adapter(
             api_key=self.api_key,
             base_url=self.base_url,
             timeout=self.timeout,
-            model=self.model
+            model=self.model,
+            provider=self.provider
         )
 
         # 最后一次调用的统计信息（用于流式调用）

--- a/hello_agents/core/llm_adapters.py
+++ b/hello_agents/core/llm_adapters.py
@@ -13,7 +13,7 @@ from .exceptions import HelloAgentsException
 class BaseLLMAdapter(ABC):
     """LLM适配器基类"""
 
-    def __init__(self, api_key: str, base_url: Optional[str], timeout: int, model: str):
+    def __init__(self, api_key: Optional[str], base_url: Optional[str], timeout: int, model: str):
         self.api_key = api_key
         self.base_url = base_url
         self.timeout = timeout
@@ -857,20 +857,271 @@ class GeminiAdapter(BaseLLMAdapter):
             raise HelloAgentsException(f"Gemini工具调用失败: {str(e)}")
 
 
+class LiteLLMAdapter(BaseLLMAdapter):
+    """LiteLLM gateway adapter (access to 100+ providers via one interface).
+
+    LiteLLM returns OpenAI-shaped responses, so parsing mirrors OpenAIAdapter.
+    Routing is by model prefix (e.g. "anthropic/claude-...", "gemini/...",
+    "bedrock/...") plus each provider's own env vars, so base_url/api_key are
+    optional here:
+    - api_key is forwarded only when set; when blank LiteLLM falls back to the
+      provider-specific env var (ANTHROPIC_API_KEY, GEMINI_API_KEY, ...).
+    - base_url is forwarded as api_base only when set (e.g. a LiteLLM proxy).
+    - drop_params=True by default so per-provider-unsupported kwargs (seed,
+      frequency_penalty, response_format, ...) are silently dropped instead of
+      raising. Pass drop_params=False to opt out.
+    """
+
+    def create_client(self) -> Any:
+        """Return the litellm module (lazy import so it stays an optional extra)."""
+        try:
+            import litellm
+        except ImportError:
+            raise HelloAgentsException(
+                "Using the LiteLLM provider requires: pip install litellm"
+            )
+        return litellm
+
+    def create_async_client(self) -> Any:
+        """LiteLLM uses the same module for sync and async calls."""
+        return self.create_client()
+
+    def _build_params(self, messages: List[Dict], **kwargs) -> Dict[str, Any]:
+        """Assemble litellm.completion kwargs, omitting blank credentials."""
+        params: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "drop_params": True,
+        }
+        if self.api_key:
+            params["api_key"] = self.api_key
+        if self.base_url:
+            params["api_base"] = self.base_url
+        if self.timeout:
+            params["timeout"] = self.timeout
+        # User kwargs win, including an explicit drop_params=False opt-out.
+        params.update(kwargs)
+        return params
+
+    def invoke(self, messages: List[Dict], **kwargs) -> LLMResponse:
+        """Non-streaming call."""
+        if not self._client:
+            self._client = self.create_client()
+
+        start_time = time.time()
+        try:
+            response = self._client.completion(**self._build_params(messages, **kwargs))
+
+            latency_ms = int((time.time() - start_time) * 1000)
+
+            choice = response.choices[0]
+            content = choice.message.content or ""
+            reasoning_content = None
+
+            if self._is_thinking_model(self.model):
+                if hasattr(choice.message, "reasoning_content"):
+                    reasoning_content = choice.message.reasoning_content
+                elif hasattr(choice, "reasoning_content"):
+                    reasoning_content = choice.reasoning_content
+
+            usage = {}
+            if hasattr(response, "usage") and response.usage:
+                usage = {
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                }
+
+            return LLMResponse(
+                content=content,
+                model=self.model,
+                usage=usage,
+                latency_ms=latency_ms,
+                reasoning_content=reasoning_content,
+            )
+
+        except HelloAgentsException:
+            raise
+        except Exception as e:
+            raise HelloAgentsException(f"LiteLLM API call failed: {str(e)}")
+
+    def stream_invoke(self, messages: List[Dict], **kwargs) -> Iterator[str]:
+        """Streaming call."""
+        if not self._client:
+            self._client = self.create_client()
+
+        start_time = time.time()
+        try:
+            response = self._client.completion(
+                stream=True, **self._build_params(messages, **kwargs)
+            )
+
+            reasoning_content = None
+            usage = {}
+
+            for chunk in response:
+                choices = getattr(chunk, "choices", None)
+                if choices:
+                    delta = getattr(choices[0], "delta", None)
+                    if delta is not None:
+                        content = getattr(delta, "content", None)
+                        if content:
+                            yield content
+
+                        if self._is_thinking_model(self.model):
+                            reasoning_delta = getattr(delta, "reasoning_content", None)
+                            if reasoning_delta:
+                                if reasoning_content is None:
+                                    reasoning_content = ""
+                                reasoning_content += reasoning_delta
+
+                if hasattr(chunk, "usage") and chunk.usage:
+                    usage = {
+                        "prompt_tokens": chunk.usage.prompt_tokens,
+                        "completion_tokens": chunk.usage.completion_tokens,
+                        "total_tokens": chunk.usage.total_tokens,
+                    }
+
+            latency_ms = int((time.time() - start_time) * 1000)
+
+            self.last_stats = StreamStats(
+                model=self.model,
+                usage=usage,
+                latency_ms=latency_ms,
+                reasoning_content=reasoning_content,
+            )
+
+        except HelloAgentsException:
+            raise
+        except Exception as e:
+            raise HelloAgentsException(f"LiteLLM API streaming call failed: {str(e)}")
+
+    async def astream_invoke(self, messages: List[Dict], **kwargs) -> AsyncIterator[str]:
+        """Native async streaming call (litellm.acompletion)."""
+        if not self._async_client:
+            self._async_client = self.create_async_client()
+
+        start_time = time.time()
+        try:
+            response = await self._async_client.acompletion(
+                stream=True, **self._build_params(messages, **kwargs)
+            )
+
+            reasoning_content = None
+            usage = {}
+
+            async for chunk in response:
+                choices = getattr(chunk, "choices", None)
+                if choices:
+                    delta = getattr(choices[0], "delta", None)
+                    if delta is not None:
+                        content = getattr(delta, "content", None)
+                        if content:
+                            yield content
+
+                        if self._is_thinking_model(self.model):
+                            reasoning_delta = getattr(delta, "reasoning_content", None)
+                            if reasoning_delta:
+                                if reasoning_content is None:
+                                    reasoning_content = ""
+                                reasoning_content += reasoning_delta
+
+                if hasattr(chunk, "usage") and chunk.usage:
+                    usage = {
+                        "prompt_tokens": chunk.usage.prompt_tokens,
+                        "completion_tokens": chunk.usage.completion_tokens,
+                        "total_tokens": chunk.usage.total_tokens,
+                    }
+
+            latency_ms = int((time.time() - start_time) * 1000)
+
+            self.last_stats = StreamStats(
+                model=self.model,
+                usage=usage,
+                latency_ms=latency_ms,
+                reasoning_content=reasoning_content,
+            )
+
+        except HelloAgentsException:
+            raise
+        except Exception as e:
+            raise HelloAgentsException(f"LiteLLM API async streaming call failed: {str(e)}")
+
+    def invoke_with_tools(self, messages: List[Dict], tools: List[Dict],
+                          tool_choice: Union[str, Dict] = "auto", **kwargs) -> LLMToolResponse:
+        """Tool call (Function Calling). LiteLLM accepts OpenAI-style tool schema."""
+        if not self._client:
+            self._client = self.create_client()
+
+        start_time = time.time()
+        try:
+            response = self._client.completion(
+                tools=tools,
+                tool_choice=tool_choice,
+                **self._build_params(messages, **kwargs),
+            )
+
+            latency_ms = int((time.time() - start_time) * 1000)
+            message = response.choices[0].message
+
+            tool_calls = []
+            if message.tool_calls:
+                for tc in message.tool_calls:
+                    tool_calls.append(ToolCall(
+                        id=tc.id,
+                        name=tc.function.name,
+                        arguments=tc.function.arguments,
+                    ))
+
+            usage = {}
+            if response.usage:
+                usage = {
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                }
+
+            return LLMToolResponse(
+                content=message.content,
+                tool_calls=tool_calls,
+                model=response.model,
+                usage=usage,
+                latency_ms=latency_ms,
+            )
+
+        except HelloAgentsException:
+            raise
+        except Exception as e:
+            raise HelloAgentsException(f"LiteLLM Function Calling failed: {str(e)}")
+
+
 def create_adapter(
-    api_key: str,
+    api_key: Optional[str],
     base_url: Optional[str],
     timeout: int,
-    model: str
+    model: str,
+    provider: Optional[str] = None
 ) -> BaseLLMAdapter:
     """
     根据base_url自动选择适配器
 
     检测逻辑：
+    - explicit provider -> matching adapter (openai/anthropic/gemini/litellm)
     - anthropic.com -> AnthropicAdapter
     - googleapis.com 或 generativelanguage -> GeminiAdapter
     - 其他 -> OpenAIAdapter（默认）
     """
+    # Explicit provider selection takes precedence over base_url auto-detection.
+    if provider:
+        explicit = {
+            "openai": OpenAIAdapter,
+            "anthropic": AnthropicAdapter,
+            "gemini": GeminiAdapter,
+            "litellm": LiteLLMAdapter,
+        }.get(provider.lower())
+        if explicit is not None:
+            return explicit(api_key, base_url, timeout, model)
+
     if base_url:
         base_url_lower = base_url.lower()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     # 核心依赖
-    "openai>=1.0.0,<2.0.0",
+    "openai>=1.0.0,<3.0.0",
     "requests>=2.25.0,<3.0.0",
     "python-dotenv>=0.19.0,<2.0.0",
     "pydantic>=2.0.0,<3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 [project.optional-dependencies]
 gemini = ["google-genai>=1.0.0"]
 anthropic = ["anthropic>=0.20.0"]
+litellm = ["litellm>=1.89.0,<2.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/jjyaoao/HelloAgents"

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -1,0 +1,213 @@
+"""Tests for the LiteLLM gateway adapter."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hello_agents.core.exceptions import HelloAgentsException
+from hello_agents.core.llm import HelloAgentsLLM
+from hello_agents.core.llm_adapters import (
+    AnthropicAdapter,
+    GeminiAdapter,
+    LiteLLMAdapter,
+    OpenAIAdapter,
+    create_adapter,
+)
+
+
+def _chat_response(content="4"):
+    return SimpleNamespace(
+        model="anthropic/claude-3-5-sonnet",
+        usage=SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+        ),
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None)
+            )
+        ],
+    )
+
+
+def _tool_schema():
+    return [{
+        "type": "function",
+        "function": {
+            "name": "calculate",
+            "description": "Run a calculation",
+            "parameters": {
+                "type": "object",
+                "properties": {"expression": {"type": "string"}},
+                "required": ["expression"],
+            },
+        },
+    }]
+
+
+def _tool_response():
+    return SimpleNamespace(
+        model="anthropic/claude-3-5-sonnet",
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="",
+                    tool_calls=[
+                        SimpleNamespace(
+                            id="call_1",
+                            function=SimpleNamespace(
+                                name="calculate",
+                                arguments='{"expression": "2+3"}',
+                            ),
+                        )
+                    ],
+                )
+            )
+        ],
+    )
+
+
+def _mock_litellm(return_value=None):
+    """A stand-in for the litellm module with mocked completion()."""
+    fake = MagicMock(name="litellm")
+    fake.completion = MagicMock(name="litellm.completion", return_value=return_value)
+    return fake
+
+
+class TestCreateAdapter:
+    def test_explicit_litellm_provider(self):
+        adapter = create_adapter(
+            api_key=None, base_url=None, timeout=60,
+            model="anthropic/claude-3-5-sonnet", provider="litellm",
+        )
+        assert isinstance(adapter, LiteLLMAdapter)
+
+    def test_explicit_provider_overrides_base_url_autodetect(self):
+        # anthropic.com would auto-detect to AnthropicAdapter, but an explicit
+        # provider must win.
+        adapter = create_adapter(
+            api_key="k", base_url="https://api.anthropic.com", timeout=60,
+            model="claude", provider="openai",
+        )
+        assert isinstance(adapter, OpenAIAdapter)
+
+    def test_no_provider_still_autodetects(self):
+        assert isinstance(
+            create_adapter("k", "https://api.anthropic.com", 60, "claude"),
+            AnthropicAdapter,
+        )
+        assert isinstance(
+            create_adapter("k", "https://generativelanguage.googleapis.com", 60, "gemini"),
+            GeminiAdapter,
+        )
+        assert isinstance(create_adapter("k", "https://api.openai.com/v1", 60, "gpt"), OpenAIAdapter)
+
+
+class TestLiteLLMAdapter:
+    def test_invoke_dispatch_and_defaults(self):
+        adapter = LiteLLMAdapter(api_key=None, base_url=None, timeout=60,
+                                 model="anthropic/claude-3-5-sonnet")
+        fake = _mock_litellm(_chat_response("4"))
+        with patch.object(LiteLLMAdapter, "create_client", return_value=fake):
+            resp = adapter.invoke([{"role": "user", "content": "2+2?"}], temperature=0.3)
+
+        fake.completion.assert_called_once()
+        call_kwargs = fake.completion.call_args[1]
+        assert call_kwargs["model"] == "anthropic/claude-3-5-sonnet"
+        assert call_kwargs["messages"] == [{"role": "user", "content": "2+2?"}]
+        # drop_params defaults to True for cross-provider compatibility.
+        assert call_kwargs["drop_params"] is True
+        assert call_kwargs["temperature"] == 0.3
+        # Blank credentials are omitted so litellm falls back to provider env vars.
+        assert "api_key" not in call_kwargs
+        assert "api_base" not in call_kwargs
+        assert resp.content == "4"
+        assert resp.usage["total_tokens"] == 15
+
+    def test_drop_params_can_be_overridden(self):
+        adapter = LiteLLMAdapter(None, None, 60, "gpt-4o-mini")
+        fake = _mock_litellm(_chat_response())
+        with patch.object(LiteLLMAdapter, "create_client", return_value=fake):
+            adapter.invoke([{"role": "user", "content": "hi"}], drop_params=False)
+        assert fake.completion.call_args[1]["drop_params"] is False
+
+    def test_credentials_forwarded_when_set(self):
+        adapter = LiteLLMAdapter(
+            api_key="sk-test", base_url="http://localhost:4000/v1", timeout=30,
+            model="gpt-4o-mini",
+        )
+        fake = _mock_litellm(_chat_response())
+        with patch.object(LiteLLMAdapter, "create_client", return_value=fake):
+            adapter.invoke([{"role": "user", "content": "hi"}])
+        call_kwargs = fake.completion.call_args[1]
+        assert call_kwargs["api_key"] == "sk-test"
+        assert call_kwargs["api_base"] == "http://localhost:4000/v1"
+        assert call_kwargs["timeout"] == 30
+
+    def test_stream_invoke_yields_content(self):
+        adapter = LiteLLMAdapter(None, None, 60, "gpt-4o-mini")
+        chunks = [
+            SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="Hel"))], usage=None),
+            SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="lo"))], usage=None),
+        ]
+        fake = _mock_litellm(iter(chunks))
+        with patch.object(LiteLLMAdapter, "create_client", return_value=fake):
+            out = list(adapter.stream_invoke([{"role": "user", "content": "hi"}]))
+        assert "".join(out) == "Hello"
+        assert fake.completion.call_args[1]["stream"] is True
+
+    def test_invoke_with_tools(self):
+        adapter = LiteLLMAdapter(None, None, 60, "anthropic/claude-3-5-sonnet")
+        fake = _mock_litellm(_tool_response())
+        with patch.object(LiteLLMAdapter, "create_client", return_value=fake):
+            resp = adapter.invoke_with_tools(
+                [{"role": "user", "content": "2+3?"}], _tool_schema(), tool_choice="auto"
+            )
+        call_kwargs = fake.completion.call_args[1]
+        assert call_kwargs["tools"] == _tool_schema()
+        assert call_kwargs["tool_choice"] == "auto"
+        assert call_kwargs["drop_params"] is True
+        assert resp.tool_calls[0].name == "calculate"
+        assert resp.tool_calls[0].arguments == '{"expression": "2+3"}'
+
+    def test_errors_wrapped(self):
+        adapter = LiteLLMAdapter(None, None, 60, "gpt-4o-mini")
+        fake = MagicMock()
+        fake.completion.side_effect = RuntimeError("boom")
+        with patch.object(LiteLLMAdapter, "create_client", return_value=fake):
+            with pytest.raises(HelloAgentsException) as exc:
+                adapter.invoke([{"role": "user", "content": "hi"}])
+        assert "LiteLLM" in str(exc.value)
+        assert "boom" in str(exc.value)
+
+    def test_missing_litellm_raises_helpful_error(self):
+        adapter = LiteLLMAdapter(None, None, 60, "gpt-4o-mini")
+        with patch("builtins.__import__", side_effect=ImportError("no litellm")):
+            with pytest.raises(HelloAgentsException) as exc:
+                adapter.create_client()
+        assert "pip install litellm" in str(exc.value)
+
+
+class TestHelloAgentsLLMLiteLLM:
+    def test_litellm_provider_needs_no_base_url_or_key(self):
+        """The litellm path routes by model prefix + provider env vars."""
+        fake = _mock_litellm(_chat_response("4"))
+        with patch.object(LiteLLMAdapter, "create_client", return_value=fake):
+            llm = HelloAgentsLLM(model="anthropic/claude-3-5-sonnet", provider="litellm")
+            resp = llm.invoke([{"role": "user", "content": "2+2?"}])
+        assert isinstance(llm._adapter, LiteLLMAdapter)
+        assert resp.content == "4"
+
+    def test_provider_from_env(self):
+        fake = _mock_litellm(_chat_response())
+        with patch.dict("os.environ", {"LLM_PROVIDER": "litellm", "LLM_MODEL_ID": "gpt-4o-mini"}):
+            with patch.object(LiteLLMAdapter, "create_client", return_value=fake):
+                llm = HelloAgentsLLM()
+        assert isinstance(llm._adapter, LiteLLMAdapter)
+
+    def test_non_litellm_still_requires_base_url(self):
+        with pytest.raises(HelloAgentsException):
+            HelloAgentsLLM(model="gpt-4o-mini", api_key="k")


### PR DESCRIPTION
## Summary
- Adds **LiteLLM** as a first class provider adapter, so a single `HelloAgentsLLM` can reach 100+ LLM providers (OpenAI, Anthropic, Gemini, Bedrock, Vertex AI, Azure, Groq, DeepSeek, Ollama, etc.) through one unified interface.
- Purely additive. Existing OpenAI / Anthropic / Gemini adapters and their auto detection are untouched.
- `litellm` stays an **optional extra**, so the base install is unaffected.

## Motivation
Today `create_adapter()` auto selects an adapter from `base_url`, which requires a user to know each provider's endpoint and give a matching `api_key` / `base_url`. LiteLLM lets a user pick a provider purely by **model prefix** (`anthropic/claude-3-5-sonnet`, `gemini/gemini-2.5-flash`, `bedrock/...`) with the provider's own env var (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, etc.), so no per provider endpoint wiring is needed. It also works against a self hosted **LiteLLM proxy**. 

## Changes
- `hello_agents/core/llm_adapters.py`: new `LiteLLMAdapter(BaseLLMAdapter)` (`invoke` / `stream_invoke` / `astream_invoke` / `invoke_with_tools` over `litellm.acompletion`). `create_adapter()` gains an optional `provider` arg for explicit selection; auto detection is unchanged when it's omitted.
- `hello_agents/core/llm.py`: `HelloAgentsLLM` gains a `provider` parameter (also read from `LLM_PROVIDER`). On the litellm path `api_key` / `base_url` are optional ; other paths are unchanged.
- `pyproject.toml`: optional `litellm` extra (`litellm>=1.89.0,<2.0.0`), plus the core `openai` pin widened to `>=1.0.0,<3.0.0` (litellm `>=1.89` needs `openai>=2.20`; the old `<2` cap made the extra uninstallable). Existing tests pass under openai 2.x.
- `tests/test_litellm_adapter.py`: 13 tests.
- 


## Tests

**1. Unit tests:** `pytest tests/test_litellm_adapter.py -v`
```
collected 13 items
tests/test_litellm_adapter.py::TestCreateAdapter::test_explicit_litellm_provider PASSED
tests/test_litellm_adapter.py::TestCreateAdapter::test_explicit_provider_overrides_base_url_autodetect PASSED
tests/test_litellm_adapter.py::TestCreateAdapter::test_no_provider_still_autodetects PASSED
tests/test_litellm_adapter.py::TestLiteLLMAdapter::test_invoke_dispatch_and_defaults PASSED
tests/test_litellm_adapter.py::TestLiteLLMAdapter::test_drop_params_can_be_overridden PASSED
tests/test_litellm_adapter.py::TestLiteLLMAdapter::test_credentials_forwarded_when_set PASSED
tests/test_litellm_adapter.py::TestLiteLLMAdapter::test_stream_invoke_yields_content PASSED
tests/test_litellm_adapter.py::TestLiteLLMAdapter::test_invoke_with_tools PASSED
tests/test_litellm_adapter.py::TestLiteLLMAdapter::test_errors_wrapped PASSED
tests/test_litellm_adapter.py::TestLiteLLMAdapter::test_missing_litellm_raises_helpful_error PASSED
tests/test_litellm_adapter.py::TestHelloAgentsLLMLiteLLM::test_litellm_provider_needs_no_base_url_or_key PASSED
tests/test_litellm_adapter.py::TestHelloAgentsLLMLiteLLM::test_provider_from_env PASSED
tests/test_litellm_adapter.py::TestHelloAgentsLLMLiteLLM::test_non_litellm_still_requires_base_url PASSED
============================== 13 passed in 0.62s ==============================
```

**2. No regressions:** existing LLM suites still pass: `pytest tests/test_llm_function_calling.py tests/test_llm_streaming.py -q` gives `7 passed, 3 skipped`.

**3. Live end to end through the real `HelloAgentsLLM` API** (via a local LiteLLM proxy, two different upstreams):
```
[invoke] litellm_proxy/gpt-4.1-mini:      content='HELLOAGENTS_LITELLM_OK'  tokens=29
[invoke] litellm_proxy/gemini-2.5-flash:  content='HELLOAGENTS_LITELLM_OK'  tokens=66
[stream] joined='4 5 6'
[tools]  tool_calls=[('get_weather', '{"city":"Paris"}')]
```
This exercises the full chain (`HelloAgentsLLM.invoke` / `stream_invoke` / `invoke_with_tools` to `LiteLLMAdapter` to `litellm.completion` to the provider and parsed back into `LLMResponse` / `LLMToolResponse`) across two providers, plus streaming and function calling.

**4. Dependency pin resolves:** after widening the core pin to `openai>=1.0.0,<3.0.0`, `uv pip install -e '.[litellm]' --dry-run` resolves cleanly (litellm 1.100.0, openai 2.54.0). The existing LLM suites still pass under openai 2.x (`test_litellm_adapter.py` plus `test_llm_function_calling.py` plus `test_llm_streaming.py` give 20 passed, 3 skipped).

## Example usage
```python
from hello_agents.core.llm import HelloAgentsLLM

# Route by model prefix plus provider env var (ANTHROPIC_API_KEY); no base_url needed.
llm = HelloAgentsLLM(model="anthropic/claude-3-5-sonnet", provider="litellm")
print(llm.invoke([{"role": "user", "content": "What is 2+2?"}]).content)

# Or point at a self-hosted LiteLLM proxy:
llm = HelloAgentsLLM(
    model="litellm_proxy/gpt-4o-mini",
    provider="litellm",
    base_url="http://localhost:4000",
    api_key="sk-...",
)
```
